### PR TITLE
feat: add AI combat log narration

### DIFF
--- a/apps/slack-bot/src/handlers/attack.ts
+++ b/apps/slack-bot/src/handlers/attack.ts
@@ -87,9 +87,8 @@ export const attackHandler = async ({ userId, say, text }: HandlerContext) => {
 
     msg += `\nCombat lasted ${combat.roundsCompleted} rounds.\n`;
 
-    // Add some combat details
-    msg += `\n\n**Combat Summary:**`;
-    msg += combat.message;
+    // Add the AI-enhanced combat narrative
+    msg += `\n${combat.message}`;
     await say({ text: msg });
     console.log(JSON.stringify(combat, null, 2));
   } catch (err: unknown) {


### PR DESCRIPTION
## Summary
- generate a structured AI prompt that returns a summary and per-round combat narration
- fall back to handcrafted round-by-round log entries when AI output is unusable and format the message for Slack
- update the Slack attack handler to surface the new combat narrative to players

## Testing
- npx nx lint slack-bot
- npx nx lint dm

------
https://chatgpt.com/codex/tasks/task_e_68cd84488bc883308c228363277caef5