### PR TITLE
Remove defeated monsters from the world

### DIFF
--- a/apps/dm/src/app/combat/combat.service.ts
+++ b/apps/dm/src/app/combat/combat.service.ts
@@ -487,13 +487,20 @@ export class CombatService {
         await this.playerService.respawnPlayer(loser.slackId);
       }
     } else {
-      await this.prisma.monster.update({
-        where: { id: loser.id },
-        data: { hp: loser.hp, isAlive: loser.isAlive },
-      });
-      this.logger.debug(
-        `Monster ${loser.name} updated: HP=${loser.hp}, alive=${loser.isAlive}`,
-      );
+      if (!loser.isAlive) {
+        await this.prisma.monster.delete({ where: { id: loser.id } });
+        this.logger.log(
+          `🗑️ Removed defeated monster ${loser.name} from the world`,
+        );
+      } else {
+        await this.prisma.monster.update({
+          where: { id: loser.id },
+          data: { hp: loser.hp, isAlive: loser.isAlive },
+        });
+        this.logger.debug(
+          `Monster ${loser.name} updated: HP=${loser.hp}, alive=${loser.isAlive}`,
+        );
+      }
     }
 
     // Award XP to winner if they're a player


### PR DESCRIPTION
## Summary
- delete defeated monsters instead of just marking them inactive
- add logging to confirm monsters are removed when they die

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd9cca676883308b9aa10faad3e3e8