### PR TITLE
Add gold rewards to combat results

### DIFF
--- a/apps/dm/src/app/graphql/types/response.types.ts
+++ b/apps/dm/src/app/graphql/types/response.types.ts
@@ -168,6 +168,9 @@ export class DetailedCombatLog {
   xpAwarded!: number;
 
   @Field()
+  goldAwarded!: number;
+
+  @Field()
   timestamp!: Date;
 
   @Field(() => CombatLocation)
@@ -196,6 +199,9 @@ export class CombatResult {
 
   @Field()
   xpGained!: number;
+
+  @Field()
+  goldGained!: number;
 
   @Field()
   message!: string;

--- a/apps/slack-bot/apps/slack-bot/src/generated/dm-graphql.ts
+++ b/apps/slack-bot/apps/slack-bot/src/generated/dm-graphql.ts
@@ -63,6 +63,7 @@ export type CombatResponse = {
 
 export type CombatResult = {
   __typename?: 'CombatResult';
+  goldGained: Scalars['Float']['output'];
   loserName: Scalars['String']['output'];
   message: Scalars['String']['output'];
   roundsCompleted: Scalars['Float']['output'];

--- a/apps/slack-bot/src/generated/dm-graphql.ts
+++ b/apps/slack-bot/src/generated/dm-graphql.ts
@@ -63,6 +63,7 @@ export type CombatResponse = {
 
 export type CombatResult = {
   __typename?: 'CombatResult';
+  goldGained: Scalars['Float']['output'];
   loserName: Scalars['String']['output'];
   message: Scalars['String']['output'];
   roundsCompleted: Scalars['Float']['output'];
@@ -476,7 +477,7 @@ export type AttackMutationVariables = Exact<{
 }>;
 
 
-export type AttackMutation = { __typename?: 'Mutation', attack: { __typename?: 'CombatResponse', success: boolean, message?: string | null, data?: { __typename?: 'CombatResult', winnerName: string, loserName: string, totalDamageDealt: number, roundsCompleted: number, xpGained: number, message: string, success: boolean } | null } };
+export type AttackMutation = { __typename?: 'Mutation', attack: { __typename?: 'CombatResponse', success: boolean, message?: string | null, data?: { __typename?: 'CombatResult', winnerName: string, loserName: string, totalDamageDealt: number, roundsCompleted: number, xpGained: number, goldGained: number, message: string, success: boolean } | null } };
 
 export type GetPlayerQueryVariables = Exact<{
   slackId: Scalars['String']['input'];
@@ -559,6 +560,7 @@ export const AttackDocument = gql`
       totalDamageDealt
       roundsCompleted
       xpGained
+      goldGained
       message
       success
     }

--- a/apps/slack-bot/src/graphql/dm.graphql
+++ b/apps/slack-bot/src/graphql/dm.graphql
@@ -27,6 +27,7 @@ mutation Attack($slackId: String!, $input: AttackInput!) {
       totalDamageDealt
       roundsCompleted
       xpGained
+      goldGained
       message
       success
     }

--- a/apps/slack-bot/src/handlers/attack.ts
+++ b/apps/slack-bot/src/handlers/attack.ts
@@ -81,6 +81,9 @@ export const attackHandler = async ({ userId, say, text }: HandlerContext) => {
       if (combat.xpGained > 0) {
         msg += `\nYou gained ${combat.xpGained} XP!`;
       }
+      if (combat.goldGained > 0) {
+        msg += `\nYou collected ${combat.goldGained} gold!`;
+      }
     } else {
       msg += `\n${defenderName} defeated you!`;
     }

--- a/dm-schema.gql
+++ b/dm-schema.gql
@@ -143,6 +143,7 @@ type CombatResult {
   totalDamageDealt: Float!
   roundsCompleted: Float!
   xpGained: Float!
+  goldGained: Float!
   message: String!
 }
 


### PR DESCRIPTION
## Summary
- calculate gold rewards using participant levels when resolving combat and persist them in combat logs
- update player stat updates and combat result payloads to grant and surface gold for victorious players
- extend Slack attack messaging and GraphQL schema/queries to include the new gold rewards

## Testing
- npx tsc -p tsconfig.json --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68ce3fe278fc8330a526871b7fef91ac