### PR TITLE
Prevent entities from entering water biomes

### DIFF
--- a/apps/dm/src/app/shared/biome.util.ts
+++ b/apps/dm/src/app/shared/biome.util.ts
@@ -1,0 +1,17 @@
+export function isWaterBiome(biomeName?: string | null): boolean {
+  if (!biomeName) {
+    return false;
+  }
+
+  const normalized = biomeName.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+
+  return (
+    normalized.includes('ocean') ||
+    normalized.includes('lake') ||
+    normalized.includes('river') ||
+    normalized.includes('water')
+  );
+}


### PR DESCRIPTION
## Summary
- block player movement into water tiles using world tile lookups
- stop monsters from moving or spawning on water tiles and reuse world biome ids
- add a shared biome helper for checking water terrain

## Testing
- npx nx test @mud/dm

------
https://chatgpt.com/codex/tasks/task_e_68d1a07c9a5c8330a938d2fee6e80b26