### PR TITLE
refactor: move app home into handler

### DIFF
--- a/apps/slack-bot/src/handlers/appHome.ts
+++ b/apps/slack-bot/src/handlers/appHome.ts
@@ -1,0 +1,63 @@
+import { App, KnownBlock } from '@slack/bolt';
+import { COMMANDS } from '../commands';
+import { buildHelpBlocks } from './help';
+
+export const buildAppHomeBlocks = (): KnownBlock[] => {
+  const helpBlocks = buildHelpBlocks();
+  return [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: '🌟 Welcome to the MUD Adventure!', emoji: true },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: 'Thanks for installing MUD Bot! Rally your party, explore the world, and team up for dungeon-delving fun.',
+      },
+    },
+    {
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: `Need a refresher later? DM me \`${COMMANDS.HELP}\` for these commands anytime.`,
+        },
+      ],
+    },
+    { type: 'divider' },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: '*🏆 Workspace Leaderboard*\n_Coming soon: see which adventurers are leading the charge in your workspace._',
+      },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: '*🌐 Global Friendly Competitions*\n_Coming soon: compare your workspace with others across the realm._',
+      },
+    },
+    { type: 'divider' },
+    ...helpBlocks,
+  ];
+};
+
+export const registerAppHome = (app: App) => {
+  app.event('app_home_opened', async ({ event, client, logger }) => {
+    try {
+      await client.views.publish({
+        user_id: event.user,
+        view: {
+          type: 'home',
+          callback_id: 'home_view',
+          blocks: buildAppHomeBlocks(),
+        },
+      });
+    } catch (error) {
+      logger.error('Failed to publish App Home', error);
+    }
+  });
+};

--- a/apps/slack-bot/src/handlers/help.ts
+++ b/apps/slack-bot/src/handlers/help.ts
@@ -1,82 +1,85 @@
+import { KnownBlock } from '@slack/bolt';
 import { HandlerContext } from './types';
 import { registerHandler } from './handlerRegistry';
 import { COMMANDS, HELP_ACTIONS } from '../commands';
 
 export const helpHandlerHelp = `Show instructions for using the bot with "help".`;
 
+export const buildHelpBlocks = (): KnownBlock[] => [
+  {
+    type: 'header',
+    text: { type: 'plain_text', text: '🎮 MUD Bot Commands', emoji: true },
+  },
+  {
+    type: 'section',
+    text: {
+      type: 'mrkdwn',
+      text: '🚀 *Quick Start*\n`new YourName` → `complete` → start exploring',
+    },
+  },
+  {
+    type: 'actions',
+    elements: [
+      {
+        type: 'button',
+        text: { type: 'plain_text', text: 'Create', emoji: true },
+        style: 'primary',
+        action_id: HELP_ACTIONS.CREATE,
+      },
+      {
+        type: 'button',
+        text: { type: 'plain_text', text: 'Look', emoji: true },
+        action_id: HELP_ACTIONS.LOOK,
+      },
+      {
+        type: 'button',
+        text: { type: 'plain_text', text: 'Stats', emoji: true },
+        action_id: HELP_ACTIONS.STATS,
+      },
+      {
+        type: 'button',
+        text: { type: 'plain_text', text: 'Map', emoji: true },
+        action_id: HELP_ACTIONS.MAP,
+      },
+    ],
+  },
+  { type: 'divider' },
+  {
+    type: 'section',
+    fields: [
+      {
+        type: 'mrkdwn',
+        text: `*Character Setup*\n• \`${COMMANDS.NEW} Name\`\n• \`${COMMANDS.REROLL}\`\n• \`${COMMANDS.COMPLETE}\`\n• \`${COMMANDS.DELETE}\``,
+      },
+      {
+        type: 'mrkdwn',
+        text: `*Explore & Fight*\n• \`${COMMANDS.NORTH}\`/\`${COMMANDS.SOUTH}\`/\`${COMMANDS.EAST}\`/\`${COMMANDS.WEST}\`\n• \`${COMMANDS.LOOK}\`\n• \`${COMMANDS.ATTACK}\`\n• \`${COMMANDS.STATS}\``,
+      },
+    ],
+  },
+  {
+    type: 'section',
+    fields: [
+      {
+        type: 'mrkdwn',
+        text: `*Other*\n• \`${COMMANDS.MAP}\`\n• \`${COMMANDS.HELP}\``,
+      },
+      {
+        type: 'mrkdwn',
+        text: `*Tips*\nDM me commands. Case-insensitive. Try \`${COMMANDS.LOOK}\` to inspect your tile.`,
+      },
+    ],
+  },
+  {
+    type: 'context',
+    elements: [{ type: 'mrkdwn', text: 'Need help? Type `help` anytime.' }],
+  },
+];
+
 export const helpHandler = async ({ say }: HandlerContext) => {
   await say({
     text: 'MUD Bot Commands',
-    blocks: [
-      {
-        type: 'header',
-        text: { type: 'plain_text', text: '🎮 MUD Bot Commands', emoji: true },
-      },
-      {
-        type: 'section',
-        text: {
-          type: 'mrkdwn',
-          text: '🚀 *Quick Start*\n`new YourName` → `complete` → start exploring',
-        },
-      },
-      {
-        type: 'actions',
-        elements: [
-          {
-            type: 'button',
-            text: { type: 'plain_text', text: 'Create', emoji: true },
-            style: 'primary',
-            action_id: HELP_ACTIONS.CREATE,
-          },
-          {
-            type: 'button',
-            text: { type: 'plain_text', text: 'Look', emoji: true },
-            action_id: HELP_ACTIONS.LOOK,
-          },
-          {
-            type: 'button',
-            text: { type: 'plain_text', text: 'Stats', emoji: true },
-            action_id: HELP_ACTIONS.STATS,
-          },
-          {
-            type: 'button',
-            text: { type: 'plain_text', text: 'Map', emoji: true },
-            action_id: HELP_ACTIONS.MAP,
-          },
-        ],
-      },
-      { type: 'divider' },
-      {
-        type: 'section',
-        fields: [
-          {
-            type: 'mrkdwn',
-            text: `*Character Setup*\n• \`${COMMANDS.NEW} Name\`\n• \`${COMMANDS.REROLL}\`\n• \`${COMMANDS.COMPLETE}\`\n• \`${COMMANDS.DELETE}\``,
-          },
-          {
-            type: 'mrkdwn',
-            text: `*Explore & Fight*\n• \`${COMMANDS.NORTH}\`/\`${COMMANDS.SOUTH}\`/\`${COMMANDS.EAST}\`/\`${COMMANDS.WEST}\`\n• \`${COMMANDS.LOOK}\`\n• \`${COMMANDS.ATTACK}\`\n• \`${COMMANDS.STATS}\``,
-          },
-        ],
-      },
-      {
-        type: 'section',
-        fields: [
-          {
-            type: 'mrkdwn',
-            text: `*Other*\n• \`${COMMANDS.MAP}\`\n• \`${COMMANDS.HELP}\``,
-          },
-          {
-            type: 'mrkdwn',
-            text: `*Tips*\nDM me commands. Case-insensitive. Try \`${COMMANDS.LOOK}\` to inspect your tile.`,
-          },
-        ],
-      },
-      {
-        type: 'context',
-        elements: [{ type: 'mrkdwn', text: 'Need help? Type `help` anytime.' }],
-      },
-    ],
+    blocks: buildHelpBlocks(),
   });
 };
 

--- a/apps/slack-bot/src/main.ts
+++ b/apps/slack-bot/src/main.ts
@@ -35,13 +35,13 @@ import './handlers/create';
 import './handlers/reroll';
 import './handlers/complete';
 import './handlers/delete';
-import './handlers/help';
 import './handlers/map';
 import './handlers/stats';
 import { getAllHandlers } from './handlers/handlerRegistry';
 import { COMMANDS } from './commands';
 import { registerActions } from './actions';
 import { SayMessage } from './handlers/types';
+import { registerAppHome } from './handlers/appHome';
 
 app.event('app_mention', async ({ event, say }) => {
   await say(
@@ -62,6 +62,8 @@ app.event('app_mention', async ({ event, say }) => {
 💡 **Send me "${COMMANDS.HELP}" for the full command list!**`,
   );
 });
+
+registerAppHome(app);
 
 app.message(async ({ message, say }) => {
   // Only handle direct user messages (not message_changed, etc)


### PR DESCRIPTION
## Summary
- extract the App Home Block Kit layout and event registration into a dedicated handler module
- register the App Home handler from main.ts so the existing logic stays intact with minimal changes elsewhere

## Testing
- npx nx build slack-bot

------
https://chatgpt.com/codex/tasks/task_e_68d7724c765c8330aea3f0d4a570e8fc