### PR TITLE
feat(slack-bot): allow choosing monsters before attacking

### DIFF
--- a/apps/slack-bot/src/actions.spec.ts
+++ b/apps/slack-bot/src/actions.spec.ts
@@ -288,7 +288,6 @@ describe('registerActions', () => {
           xpGained: 2,
           goldGained: 1,
           message: 'Hero strikes down the goblin.',
-          success: true,
         },
       },
     });

--- a/apps/slack-bot/src/commands.ts
+++ b/apps/slack-bot/src/commands.ts
@@ -50,3 +50,8 @@ export const MOVE_ACTIONS = {
   EAST: 'move_action_east',
   WEST: 'move_action_west',
 } as const;
+
+export const ATTACK_ACTIONS = {
+  MONSTER_SELECT: 'attack_action_monster_select',
+  ATTACK_MONSTER: 'attack_action_attack_monster',
+} as const;


### PR DESCRIPTION
## Summary
- present nearby monsters with a Block Kit dropdown and attack button instead of auto-attacking the first target
- handle the new attack button action by triggering the selected monster combat and reuse the shared combat summary
- extend Slack bot tests to cover the monster selection UI and button workflow

## Testing
- yarn jest --config apps/slack-bot/jest.config.js apps/slack-bot/src/actions.spec.ts
- yarn jest --config ./apps/slack-bot/jest.config.js ./apps/slack-bot/src/handlers/commandHandlers.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68dca3b005e88330ba6d4cd3557c9c2d