### PR TITLE
Add leveling skill point logic and Slack stat upgrades

### DIFF
--- a/apps/dm/src/app/graphql/inputs/player.input.ts
+++ b/apps/dm/src/app/graphql/inputs/player.input.ts
@@ -21,6 +21,16 @@ registerEnumType(Direction, {
   description: 'Cardinal directions for player movement',
 });
 
+export enum PlayerAttribute {
+  STRENGTH = 'strength',
+  AGILITY = 'agility',
+  HEALTH = 'health',
+}
+
+registerEnumType(PlayerAttribute, {
+  name: 'PlayerAttribute',
+});
+
 @InputType()
 export class CreatePlayerInput {
   @Field()

--- a/apps/dm/src/app/graphql/models/player.model.ts
+++ b/apps/dm/src/app/graphql/models/player.model.ts
@@ -43,6 +43,9 @@ export class Player {
   @Field(() => Int)
   level!: number;
 
+  @Field(() => Int)
+  skillPoints!: number;
+
   @Field()
   isAlive!: boolean;
 

--- a/apps/dm/src/app/graphql/resolvers/player.resolver.ts
+++ b/apps/dm/src/app/graphql/resolvers/player.resolver.ts
@@ -26,6 +26,7 @@ import {
   PlayerStatsInput,
   AttackInput,
   TargetType,
+  PlayerAttribute,
 } from '../inputs/player.input';
 
 @Resolver(() => Player)
@@ -121,6 +122,28 @@ export class PlayerResolver {
           error instanceof Error
             ? error.message
             : 'Failed to update player stats',
+      };
+    }
+  }
+
+  @Mutation(() => PlayerResponse)
+  async spendSkillPoint(
+    @Args('slackId') slackId: string,
+    @Args('attribute', { type: () => PlayerAttribute }) attribute: PlayerAttribute,
+  ): Promise<PlayerResponse> {
+    try {
+      const player = await this.playerService.spendSkillPoint(slackId, attribute);
+      return {
+        success: true,
+        data: player as Player,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        message:
+          error instanceof Error
+            ? error.message
+            : 'Failed to spend skill point',
       };
     }
   }

--- a/apps/slack-bot/src/actions.spec.ts
+++ b/apps/slack-bot/src/actions.spec.ts
@@ -1,6 +1,7 @@
 jest.mock('./gql-client', () => {
   const dmSdk = {
     Attack: jest.fn(),
+    SpendSkillPoint: jest.fn(),
   };
   return { dmSdk };
 });
@@ -11,13 +12,17 @@ import {
   HELP_ACTIONS,
   MOVE_ACTIONS,
   ATTACK_ACTIONS,
+  STAT_ACTIONS,
 } from './commands';
 import { getAllHandlers } from './handlers/handlerRegistry';
 import { HandlerContext } from './handlers/types';
 import { dmSdk } from './gql-client';
-import { TargetType } from './generated/dm-graphql';
+import { PlayerAttribute, TargetType } from './generated/dm-graphql';
 
-const mockedDmSdk = dmSdk as unknown as { Attack: jest.Mock };
+const mockedDmSdk = dmSdk as unknown as {
+  Attack: jest.Mock;
+  SpendSkillPoint: jest.Mock;
+};
 
 type AckMock = jest.Mock<Promise<void>, unknown[]>;
 type ConversationsOpenMock = jest.Mock<
@@ -25,11 +30,12 @@ type ConversationsOpenMock = jest.Mock<
   unknown[]
 >;
 type ChatPostMessageMock = jest.Mock<Promise<void>, unknown[]>;
+type ChatUpdateMock = jest.Mock<Promise<void>, unknown[]>;
 type ViewsOpenMock = jest.Mock<Promise<void>, unknown[]>;
 
 type MockSlackClient = {
   conversations: { open: ConversationsOpenMock };
-  chat: { postMessage: ChatPostMessageMock };
+  chat: { postMessage: ChatPostMessageMock; update: ChatUpdateMock };
   views?: { open: ViewsOpenMock };
 };
 
@@ -41,8 +47,10 @@ type SlackActionHandler = (args: {
     state?: { values?: Record<string, Record<string, unknown>> };
     container?: { channel_id?: string };
     channel?: { id?: string };
+    message?: { ts?: string };
   };
   client: MockSlackClient;
+  respond?: jest.Mock;
 }) => Promise<void> | void;
 
 type SlackViewHandler = (args: {
@@ -74,6 +82,7 @@ describe('registerActions', () => {
     actionHandlers = {};
     viewHandlers = {};
     mockedDmSdk.Attack.mockReset();
+    mockedDmSdk.SpendSkillPoint.mockReset();
     const app = {
       action: jest.fn((actionId: string, handler: SlackActionHandler) => {
         actionHandlers[actionId] = handler;
@@ -109,6 +118,7 @@ describe('registerActions', () => {
         postMessage: jest
           .fn()
           .mockResolvedValue(undefined) as ChatPostMessageMock,
+        update: jest.fn().mockResolvedValue(undefined) as ChatUpdateMock,
       },
     };
 
@@ -147,6 +157,7 @@ describe('registerActions', () => {
         postMessage: jest
           .fn()
           .mockResolvedValue(undefined) as ChatPostMessageMock,
+        update: jest.fn().mockResolvedValue(undefined) as ChatUpdateMock,
       },
     };
 
@@ -173,6 +184,7 @@ describe('registerActions', () => {
         postMessage: jest
           .fn()
           .mockResolvedValue(undefined) as ChatPostMessageMock,
+        update: jest.fn().mockResolvedValue(undefined) as ChatUpdateMock,
       },
       views: { open: viewsOpen },
     };
@@ -215,6 +227,7 @@ describe('registerActions', () => {
         postMessage: jest
           .fn()
           .mockResolvedValue(undefined) as ChatPostMessageMock,
+        update: jest.fn().mockResolvedValue(undefined) as ChatUpdateMock,
       },
     };
 
@@ -270,6 +283,7 @@ describe('registerActions', () => {
         postMessage: jest
           .fn()
           .mockResolvedValue(undefined) as ChatPostMessageMock,
+        update: jest.fn().mockResolvedValue(undefined) as ChatUpdateMock,
       },
     };
 
@@ -335,6 +349,7 @@ describe('registerActions', () => {
         postMessage: jest
           .fn()
           .mockResolvedValue(undefined) as ChatPostMessageMock,
+        update: jest.fn().mockResolvedValue(undefined) as ChatUpdateMock,
       },
     };
 
@@ -360,6 +375,7 @@ describe('registerActions', () => {
         postMessage: jest
           .fn()
           .mockResolvedValue(undefined) as ChatPostMessageMock,
+        update: jest.fn().mockResolvedValue(undefined) as ChatUpdateMock,
       },
     };
 
@@ -388,6 +404,7 @@ describe('registerActions', () => {
         postMessage: jest
           .fn()
           .mockResolvedValue(undefined) as ChatPostMessageMock,
+        update: jest.fn().mockResolvedValue(undefined) as ChatUpdateMock,
       },
     };
 
@@ -412,6 +429,7 @@ describe('registerActions', () => {
         postMessage: jest
           .fn()
           .mockResolvedValue(undefined) as ChatPostMessageMock,
+        update: jest.fn().mockResolvedValue(undefined) as ChatUpdateMock,
       },
     };
 
@@ -442,6 +460,7 @@ describe('registerActions', () => {
         postMessage: jest
           .fn()
           .mockResolvedValue(undefined) as ChatPostMessageMock,
+        update: jest.fn().mockResolvedValue(undefined) as ChatUpdateMock,
       },
       views: { open: viewsOpen },
     };
@@ -471,6 +490,7 @@ describe('registerActions', () => {
         postMessage: jest
           .fn()
           .mockResolvedValue(undefined) as ChatPostMessageMock,
+        update: jest.fn().mockResolvedValue(undefined) as ChatUpdateMock,
       },
       views: { open: viewsOpen },
     };
@@ -499,6 +519,7 @@ describe('registerActions', () => {
         postMessage: jest
           .fn()
           .mockResolvedValue(undefined) as ChatPostMessageMock,
+        update: jest.fn().mockResolvedValue(undefined) as ChatUpdateMock,
       },
     };
 
@@ -531,6 +552,7 @@ describe('registerActions', () => {
         postMessage: jest
           .fn()
           .mockResolvedValue(undefined) as ChatPostMessageMock,
+        update: jest.fn().mockResolvedValue(undefined) as ChatUpdateMock,
       },
     };
 
@@ -569,6 +591,7 @@ describe('registerActions', () => {
         postMessage: jest
           .fn()
           .mockResolvedValue(undefined) as ChatPostMessageMock,
+        update: jest.fn().mockResolvedValue(undefined) as ChatUpdateMock,
       },
     };
 
@@ -602,6 +625,7 @@ describe('registerActions', () => {
         postMessage: jest
           .fn()
           .mockResolvedValue(undefined) as ChatPostMessageMock,
+        update: jest.fn().mockResolvedValue(undefined) as ChatUpdateMock,
       },
     };
 
@@ -626,6 +650,7 @@ describe('registerActions', () => {
         postMessage: jest
           .fn()
           .mockResolvedValue(undefined) as ChatPostMessageMock,
+        update: jest.fn().mockResolvedValue(undefined) as ChatUpdateMock,
       },
     };
 
@@ -659,6 +684,7 @@ describe('registerActions', () => {
         postMessage: jest
           .fn()
           .mockResolvedValue(undefined) as ChatPostMessageMock,
+        update: jest.fn().mockResolvedValue(undefined) as ChatUpdateMock,
       },
     };
 
@@ -710,6 +736,7 @@ describe('registerActions', () => {
         postMessage: jest
           .fn()
           .mockResolvedValue(undefined) as ChatPostMessageMock,
+        update: jest.fn().mockResolvedValue(undefined) as ChatUpdateMock,
       },
     };
 
@@ -761,6 +788,7 @@ describe('registerActions', () => {
         postMessage: jest
           .fn()
           .mockResolvedValue(undefined) as ChatPostMessageMock,
+        update: jest.fn().mockResolvedValue(undefined) as ChatUpdateMock,
       },
     };
 
@@ -812,6 +840,7 @@ describe('registerActions', () => {
         postMessage: jest
           .fn()
           .mockResolvedValue(undefined) as ChatPostMessageMock,
+        update: jest.fn().mockResolvedValue(undefined) as ChatUpdateMock,
       },
     };
 
@@ -849,6 +878,7 @@ describe('registerActions', () => {
         postMessage: jest
           .fn()
           .mockResolvedValue(undefined) as ChatPostMessageMock,
+        update: jest.fn().mockResolvedValue(undefined) as ChatUpdateMock,
       },
     };
 
@@ -886,6 +916,7 @@ describe('registerActions', () => {
         postMessage: jest
           .fn()
           .mockResolvedValue(undefined) as ChatPostMessageMock,
+        update: jest.fn().mockResolvedValue(undefined) as ChatUpdateMock,
       },
     };
 
@@ -896,5 +927,102 @@ describe('registerActions', () => {
     });
 
     expect(ack).toHaveBeenCalled();
+  });
+
+  it('spends skill points and updates the stats message', async () => {
+    const ack = jest.fn().mockResolvedValue(undefined) as AckMock;
+    const respond = jest.fn();
+    mockedDmSdk.SpendSkillPoint.mockResolvedValue({
+      spendSkillPoint: {
+        success: true,
+        message: null,
+        data: {
+          id: '1',
+          slackId: 'U1',
+          name: 'Hero',
+          hp: 18,
+          maxHp: 18,
+          strength: 12,
+          agility: 10,
+          health: 11,
+          gold: 5,
+          xp: 150,
+          level: 2,
+          skillPoints: 1,
+        },
+      },
+    });
+
+    const client: MockSlackClient = {
+      conversations: {
+        open: jest.fn() as ConversationsOpenMock,
+      },
+      chat: {
+        postMessage: jest
+          .fn()
+          .mockResolvedValue(undefined) as ChatPostMessageMock,
+        update: jest.fn().mockResolvedValue(undefined) as ChatUpdateMock,
+      },
+    };
+
+    await actionHandlers[STAT_ACTIONS.INCREASE_STRENGTH]({
+      ack,
+      body: {
+        user: { id: 'U1' },
+        channel: { id: 'C1' },
+        message: { ts: '123' },
+      },
+      client,
+      respond,
+    });
+
+    expect(mockedDmSdk.SpendSkillPoint).toHaveBeenCalledWith({
+      slackId: 'U1',
+      attribute: PlayerAttribute.Strength,
+    });
+    expect(client.chat.update).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: 'C1', ts: '123' }),
+    );
+    expect(respond).not.toHaveBeenCalled();
+  });
+
+  it('reports errors when spending skill points fails', async () => {
+    const ack = jest.fn().mockResolvedValue(undefined) as AckMock;
+    const respond = jest.fn();
+    mockedDmSdk.SpendSkillPoint.mockResolvedValue({
+      spendSkillPoint: { success: false, message: 'no points', data: null },
+    });
+
+    const client: MockSlackClient = {
+      conversations: {
+        open: jest.fn() as ConversationsOpenMock,
+      },
+      chat: {
+        postMessage: jest
+          .fn()
+          .mockResolvedValue(undefined) as ChatPostMessageMock,
+        update: jest.fn().mockResolvedValue(undefined) as ChatUpdateMock,
+      },
+    };
+
+    await actionHandlers[STAT_ACTIONS.INCREASE_AGILITY]({
+      ack,
+      body: {
+        user: { id: 'U1' },
+        channel: { id: 'C1' },
+        message: { ts: '123' },
+      },
+      client,
+      respond,
+    });
+
+    expect(mockedDmSdk.SpendSkillPoint).toHaveBeenCalledWith({
+      slackId: 'U1',
+      attribute: PlayerAttribute.Agility,
+    });
+    expect(client.chat.update).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      expect.objectContaining({ response_type: 'ephemeral' }),
+    );
   });
 });

--- a/apps/slack-bot/src/commands.ts
+++ b/apps/slack-bot/src/commands.ts
@@ -55,3 +55,9 @@ export const ATTACK_ACTIONS = {
   MONSTER_SELECT: 'attack_action_monster_select',
   ATTACK_MONSTER: 'attack_action_attack_monster',
 } as const;
+
+export const STAT_ACTIONS = {
+  INCREASE_STRENGTH: 'stats_action_increase_strength',
+  INCREASE_AGILITY: 'stats_action_increase_agility',
+  INCREASE_HEALTH: 'stats_action_increase_health',
+} as const;

--- a/apps/slack-bot/src/generated/dm-graphql.ts
+++ b/apps/slack-bot/src/generated/dm-graphql.ts
@@ -226,6 +226,7 @@ export type Mutation = {
   processTick: SuccessResponse;
   rerollPlayerStats: PlayerResponse;
   respawn: PlayerResponse;
+  spendSkillPoint: PlayerResponse;
   spawnMonster: MonsterResponse;
   updatePlayerStats: PlayerResponse;
 };
@@ -271,6 +272,12 @@ export type MutationRerollPlayerStatsArgs = {
 
 
 export type MutationRespawnArgs = {
+  slackId: Scalars['String']['input'];
+};
+
+
+export type MutationSpendSkillPointArgs = {
+  attribute: PlayerAttribute;
   slackId: Scalars['String']['input'];
 };
 
@@ -326,6 +333,7 @@ export type Player = {
   name: Scalars['String']['output'];
   nearbyMonsters?: Maybe<Array<Monster>>;
   nearbyPlayers?: Maybe<Array<Player>>;
+  skillPoints: Scalars['Int']['output'];
   slackId: Scalars['String']['output'];
   strength: Scalars['Int']['output'];
   updatedAt: Scalars['DateTime']['output'];
@@ -429,6 +437,12 @@ export type SuccessResponse = {
   success: Scalars['Boolean']['output'];
 };
 
+export enum PlayerAttribute {
+  Agility = 'AGILITY',
+  Health = 'HEALTH',
+  Strength = 'STRENGTH'
+}
+
 export enum TargetType {
   Monster = 'MONSTER',
   Player = 'PLAYER'
@@ -496,7 +510,7 @@ export type GetPlayerQueryVariables = Exact<{
 }>;
 
 
-export type GetPlayerQuery = { __typename?: 'Query', getPlayer: { __typename?: 'PlayerResponse', success: boolean, message?: string | null, data?: { __typename?: 'Player', id: string, name: string, x: number, y: number, hp: number, maxHp: number, strength: number, agility: number, health: number, gold: number, xp: number, level: number, isAlive: boolean, nearbyMonsters?: Array<{ __typename?: 'Monster', id: string, name: string, hp: number, isAlive: boolean }> | null } | null } };
+export type GetPlayerQuery = { __typename?: 'Query', getPlayer: { __typename?: 'PlayerResponse', success: boolean, message?: string | null, data?: { __typename?: 'Player', id: string, slackId: string, name: string, x: number, y: number, hp: number, maxHp: number, strength: number, agility: number, health: number, gold: number, xp: number, level: number, skillPoints: number, isAlive: boolean, nearbyMonsters?: Array<{ __typename?: 'Monster', id: string, name: string, hp: number, isAlive: boolean }> | null } | null } };
 
 export type GetLocationEntitiesQueryVariables = Exact<{
   x: Scalars['Float']['input'];
@@ -504,14 +518,14 @@ export type GetLocationEntitiesQueryVariables = Exact<{
 }>;
 
 
-export type GetLocationEntitiesQuery = { __typename?: 'Query', getPlayersAtLocation: Array<{ __typename?: 'Player', id: string, slackId: string, name: string, x: number, y: number, hp: number, maxHp: number, strength: number, agility: number, health: number, gold: number, xp: number, level: number, isAlive: boolean }>, getMonstersAtLocation: Array<{ __typename?: 'Monster', id: string, name: string, type: string, hp: number, maxHp: number, strength: number, agility: number, health: number, x: number, y: number, isAlive: boolean }> };
+export type GetLocationEntitiesQuery = { __typename?: 'Query', getPlayersAtLocation: Array<{ __typename?: 'Player', id: string, slackId: string, name: string, x: number, y: number, hp: number, maxHp: number, strength: number, agility: number, health: number, gold: number, xp: number, level: number, skillPoints: number, isAlive: boolean }>, getMonstersAtLocation: Array<{ __typename?: 'Monster', id: string, name: string, type: string, hp: number, maxHp: number, strength: number, agility: number, health: number, x: number, y: number, isAlive: boolean }> };
 
 export type GetPlayerWithLocationQueryVariables = Exact<{
   slackId: Scalars['String']['input'];
 }>;
 
 
-export type GetPlayerWithLocationQuery = { __typename?: 'Query', getPlayer: { __typename?: 'PlayerResponse', success: boolean, message?: string | null, data?: { __typename?: 'Player', id: string, name: string, x: number, y: number, hp: number, maxHp: number, strength: number, agility: number, health: number, gold: number, xp: number, level: number, isAlive: boolean, nearbyMonsters?: Array<{ __typename?: 'Monster', id: string, name: string, hp: number, isAlive: boolean }> | null, currentTile?: { __typename?: 'TileInfo', x: number, y: number, biomeName: string, description?: string | null, height: number, temperature: number, moisture: number } | null, nearbyPlayers?: Array<{ __typename?: 'Player', id: string, name: string, hp: number, isAlive: boolean }> | null } | null } };
+export type GetPlayerWithLocationQuery = { __typename?: 'Query', getPlayer: { __typename?: 'PlayerResponse', success: boolean, message?: string | null, data?: { __typename?: 'Player', id: string, slackId: string, name: string, x: number, y: number, hp: number, maxHp: number, strength: number, agility: number, health: number, gold: number, xp: number, level: number, skillPoints: number, isAlive: boolean, nearbyMonsters?: Array<{ __typename?: 'Monster', id: string, name: string, hp: number, isAlive: boolean }> | null, currentTile?: { __typename?: 'TileInfo', x: number, y: number, biomeName: string, description?: string | null, height: number, temperature: number, moisture: number } | null, nearbyPlayers?: Array<{ __typename?: 'Player', id: string, name: string, hp: number, isAlive: boolean }> | null } | null } };
 
 export type GetLookViewQueryVariables = Exact<{
   slackId: Scalars['String']['input'];
@@ -525,7 +539,7 @@ export type CreatePlayerMutationVariables = Exact<{
 }>;
 
 
-export type CreatePlayerMutation = { __typename?: 'Mutation', createPlayer: { __typename?: 'PlayerResponse', success: boolean, message?: string | null, data?: { __typename?: 'Player', id: string, slackId: string, name: string, x: number, y: number, hp: number, maxHp: number, strength: number, agility: number, health: number, gold: number, xp: number, level: number, isAlive: boolean, updatedAt: any } | null } };
+export type CreatePlayerMutation = { __typename?: 'Mutation', createPlayer: { __typename?: 'PlayerResponse', success: boolean, message?: string | null, data?: { __typename?: 'Player', id: string, slackId: string, name: string, x: number, y: number, hp: number, maxHp: number, strength: number, agility: number, health: number, gold: number, xp: number, level: number, skillPoints: number, isAlive: boolean, updatedAt: any } | null } };
 
 export type RerollPlayerStatsMutationVariables = Exact<{
   slackId: Scalars['String']['input'];
@@ -533,6 +547,14 @@ export type RerollPlayerStatsMutationVariables = Exact<{
 
 
 export type RerollPlayerStatsMutation = { __typename?: 'Mutation', rerollPlayerStats: { __typename?: 'PlayerResponse', success: boolean, message?: string | null, data?: { __typename?: 'Player', id: string, slackId: string, name: string, strength: number, agility: number, health: number, maxHp: number } | null } };
+
+export type SpendSkillPointMutationVariables = Exact<{
+  slackId: Scalars['String']['input'];
+  attribute: PlayerAttribute;
+}>;
+
+
+export type SpendSkillPointMutation = { __typename?: 'Mutation', spendSkillPoint: { __typename?: 'PlayerResponse', success: boolean, message?: string | null, data?: { __typename?: 'Player', id: string, slackId: string, name: string, hp: number, maxHp: number, strength: number, agility: number, health: number, gold: number, xp: number, level: number, skillPoints: number } | null } };
 
 export type CompletePlayerMutationVariables = Exact<{
   slackId: Scalars['String']['input'];
@@ -599,6 +621,7 @@ export const GetPlayerDocument = gql`
     message
     data {
       id
+      slackId
       name
       x
       y
@@ -610,6 +633,7 @@ export const GetPlayerDocument = gql`
       gold
       xp
       level
+      skillPoints
       isAlive
       nearbyMonsters {
         id
@@ -637,6 +661,7 @@ export const GetLocationEntitiesDocument = gql`
     gold
     xp
     level
+    skillPoints
     isAlive
   }
   getMonstersAtLocation(x: $x, y: $y) {
@@ -661,6 +686,7 @@ export const GetPlayerWithLocationDocument = gql`
     message
     data {
       id
+      slackId
       name
       x
       y
@@ -672,6 +698,7 @@ export const GetPlayerWithLocationDocument = gql`
       gold
       xp
       level
+      skillPoints
       isAlive
       nearbyMonsters {
         id
@@ -774,6 +801,7 @@ export const CreatePlayerDocument = gql`
       gold
       xp
       level
+      skillPoints
       isAlive
       updatedAt
     }
@@ -793,6 +821,28 @@ export const RerollPlayerStatsDocument = gql`
       agility
       health
       maxHp
+    }
+  }
+}
+    `;
+export const SpendSkillPointDocument = gql`
+    mutation SpendSkillPoint($slackId: String!, $attribute: PlayerAttribute!) {
+  spendSkillPoint(slackId: $slackId, attribute: $attribute) {
+    success
+    message
+    data {
+      id
+      slackId
+      name
+      hp
+      maxHp
+      strength
+      agility
+      health
+      gold
+      xp
+      level
+      skillPoints
     }
   }
 }
@@ -855,6 +905,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     RerollPlayerStats(variables: RerollPlayerStatsMutationVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<RerollPlayerStatsMutation> {
       return withWrapper((wrappedRequestHeaders) => client.request<RerollPlayerStatsMutation>({ document: RerollPlayerStatsDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'RerollPlayerStats', 'mutation', variables);
+    },
+    SpendSkillPoint(variables: SpendSkillPointMutationVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<SpendSkillPointMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<SpendSkillPointMutation>({ document: SpendSkillPointDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'SpendSkillPoint', 'mutation', variables);
     },
     CompletePlayer(variables: CompletePlayerMutationVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<CompletePlayerMutation> {
       return withWrapper((wrappedRequestHeaders) => client.request<CompletePlayerMutation>({ document: CompletePlayerDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'CompletePlayer', 'mutation', variables);

--- a/apps/slack-bot/src/graphql/dm.graphql
+++ b/apps/slack-bot/src/graphql/dm.graphql
@@ -45,6 +45,7 @@ query GetPlayer($slackId: String, $name: String) {
     message
     data {
       id
+      slackId
       name
       x
       y
@@ -56,6 +57,7 @@ query GetPlayer($slackId: String, $name: String) {
       gold
       xp
       level
+      skillPoints
       isAlive
       nearbyMonsters {
         id
@@ -82,6 +84,7 @@ query GetLocationEntities($x: Float!, $y: Float!) {
     gold
     xp
     level
+    skillPoints
     isAlive
   }
   getMonstersAtLocation(x: $x, y: $y) {
@@ -105,6 +108,7 @@ query GetPlayerWithLocation($slackId: String!) {
     message
     data {
       id
+      slackId
       name
       x
       y
@@ -116,6 +120,7 @@ query GetPlayerWithLocation($slackId: String!) {
       gold
       xp
       level
+      skillPoints
       isAlive
       nearbyMonsters {
         id
@@ -216,8 +221,30 @@ mutation CreatePlayer($input: CreatePlayerInput!) {
       gold
       xp
       level
+      skillPoints
       isAlive
       updatedAt
+    }
+  }
+}
+
+mutation SpendSkillPoint($slackId: String!, $attribute: PlayerAttribute!) {
+  spendSkillPoint(slackId: $slackId, attribute: $attribute) {
+    success
+    message
+    data {
+      id
+      slackId
+      name
+      hp
+      maxHp
+      strength
+      agility
+      health
+      gold
+      xp
+      level
+      skillPoints
     }
   }
 }

--- a/apps/slack-bot/src/handlers/commandHandlers.spec.ts
+++ b/apps/slack-bot/src/handlers/commandHandlers.spec.ts
@@ -49,7 +49,10 @@ type MockSlackClient = {
   conversations: {
     open: jest.Mock<Promise<{ channel: { id: string } }>, [{ users: string }]>;
   };
-  chat: { postMessage: jest.Mock<Promise<void>, [Record<string, unknown>]> };
+  chat: {
+    postMessage: jest.Mock<Promise<void>, [Record<string, unknown>]>;
+    update: jest.Mock<Promise<void>, [Record<string, unknown>]>;
+  };
 };
 
 const makeSay = () =>
@@ -67,6 +70,9 @@ const makeClient = (channelId = 'D1'): MockSlackClient => ({
     postMessage: jest
       .fn<Promise<void>, [Record<string, unknown>]>()
       .mockResolvedValue(undefined),
+    update: jest
+      .fn<Promise<void>, [Record<string, unknown>]>()
+      .mockResolvedValue(undefined),
   },
 });
 
@@ -76,10 +82,14 @@ beforeEach(() => {
     getPlayer: {
       success: true,
       data: {
+        id: '1',
+        slackId: 'U1',
         name: 'Hero',
         hp: 1,
+        maxHp: 10,
         level: 1,
         xp: 0,
+        skillPoints: 0,
         x: 0,
         y: 0,
         nearbyMonsters: [],
@@ -267,6 +277,7 @@ describe('createHandler', () => {
           gold: 0,
           xp: 0,
           level: 1,
+          skillPoints: 0,
           x: 0,
           y: 0,
         },
@@ -285,6 +296,14 @@ describe('createHandler', () => {
     expect(say).toHaveBeenLastCalledWith(
       expect.objectContaining({
         text: expect.stringContaining('Welcome <@U1>!'),
+        blocks: expect.arrayContaining([
+          expect.objectContaining({
+            type: 'section',
+            text: expect.objectContaining({
+              text: expect.stringContaining('Welcome <@U1>!'),
+            }),
+          }),
+        ]),
       }),
     );
   });

--- a/apps/slack-bot/src/handlers/create.ts
+++ b/apps/slack-bot/src/handlers/create.ts
@@ -3,7 +3,7 @@ import { HandlerContext } from './types';
 import { registerHandler } from './handlerRegistry';
 import { getUserFriendlyErrorMessage } from './errorUtils';
 import { COMMANDS } from '../commands';
-import { formatPlayerStats } from './stats/format';
+import { buildPlayerStatsMessage } from './stats/format';
 
 export const createHandlerHelp = `Create a new character with "new". Example: Send "new AwesomeDude" to create a character named AwesomeDude.`;
 
@@ -37,9 +37,25 @@ export const createHandler = async ({ userId, say, text }: HandlerContext) => {
   try {
     const result = await dmSdk.CreatePlayer({ input });
     if (result.createPlayer.success && result.createPlayer.data) {
-      const statsMsg = formatPlayerStats(result.createPlayer.data);
+      const introText = `Welcome <@${userId}>! Your character creation has started.`;
+      const instructions =
+        'Use "reroll" to reroll your stats, and "complete" when you are done.';
+      const statsMessage = buildPlayerStatsMessage(result.createPlayer.data, {
+        isSelf: true,
+      });
       await say({
-        text: `Welcome <@${userId}>! Your character creation has started.\n${statsMsg}\nSend "reroll" to reroll your stats, and "complete" when you are done.`,
+        text: `${introText} ${instructions} ${statsMessage.text}`,
+        blocks: [
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: `${introText}\n${instructions}`,
+            },
+          },
+          { type: 'divider' },
+          ...statsMessage.blocks,
+        ],
       });
     } else {
       console.log('CreatePlayer error:', result.createPlayer);

--- a/apps/slack-bot/src/handlers/stats/format.ts
+++ b/apps/slack-bot/src/handlers/stats/format.ts
@@ -1,43 +1,198 @@
+import type { KnownBlock, Block } from '@slack/types';
+import { SayMessage } from '../types';
 import { MonsterStatsSource, PlayerStatsSource } from './types';
+import { STAT_ACTIONS } from '../../commands';
+
+type PlayerStatsFormatOptions = {
+  isSelf?: boolean;
+};
 
 const displayValue = (value: unknown) =>
-  value === undefined || value === null ? '?' : value;
+  value === undefined || value === null ? '—' : String(value);
 
-export function formatPlayerStats(player: PlayerStatsSource): string {
-  const incomplete = [
+const attributeWithModifier = (value: number | null | undefined): string => {
+  if (value == null) {
+    return '—';
+  }
+  const modifier = Math.floor((value - 10) / 2);
+  const sign = modifier >= 0 ? '+' : '';
+  return `${value} (${sign}${modifier})`;
+};
+
+const buildActionsBlock = (skillPoints: number): (KnownBlock | Block)[] => {
+  if (!skillPoints || skillPoints <= 0) {
+    return [];
+  }
+
+  return [
+    {
+      type: 'actions',
+      block_id: 'skill_point_spend',
+      elements: [
+        {
+          type: 'button',
+          action_id: STAT_ACTIONS.INCREASE_STRENGTH,
+          text: { type: 'plain_text', text: 'Increase Strength', emoji: true },
+          style: 'primary',
+          value: 'strength',
+        },
+        {
+          type: 'button',
+          action_id: STAT_ACTIONS.INCREASE_AGILITY,
+          text: { type: 'plain_text', text: 'Increase Agility', emoji: true },
+          style: 'primary',
+          value: 'agility',
+        },
+        {
+          type: 'button',
+          action_id: STAT_ACTIONS.INCREASE_HEALTH,
+          text: { type: 'plain_text', text: 'Increase Vitality', emoji: true },
+          style: 'primary',
+          value: 'health',
+        },
+      ],
+    },
+  ];
+};
+
+export function buildPlayerStatsMessage(
+  player: PlayerStatsSource,
+  options: PlayerStatsFormatOptions = {},
+): SayMessage {
+  const skillPoints = player.skillPoints ?? 0;
+  const name = displayValue(player.name);
+  const title = `${name} — Level ${displayValue(player.level)}`;
+  const hpText = `${displayValue(player.hp)}/${displayValue(player.maxHp)}`;
+
+  const blocks: (KnownBlock | Block)[] = [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: `${name}'s Stats`, emoji: true },
+    },
+  ];
+
+  const incompleteStats = [
     player.strength,
     player.agility,
     player.health,
     player.maxHp,
-  ].some((v) => v == null || v === 0)
-    ? '_Character creation not complete! Use "reroll" to reroll stats, "complete" to finish._\n'
-    : '';
+  ].some((v) => v == null || v === 0);
 
-  return (
-    `${incomplete}` +
-    `*Stats*\n` +
-    `- Name: ${displayValue(player.name)}\n` +
-    `- Strength: ${displayValue(player.strength)}\n` +
-    `- Agility: ${displayValue(player.agility)}\n` +
-    `- Health: ${displayValue(player.health)}\n` +
-    `- HP: ${displayValue(player.hp)}/${displayValue(player.maxHp)}\n` +
-    `- Gold: ${displayValue(player.gold)}\n` +
-    `- XP: ${displayValue(player.xp)}\n` +
-    `- Level: ${displayValue(player.level)}\n` +
-    `- Position: ${displayValue(player.x)}/${displayValue(player.y)}`
-  );
+  if (incompleteStats) {
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text:
+          '_Character creation not complete! Use "reroll" to reroll stats, "complete" to finish._',
+      },
+    });
+  }
+
+  blocks.push({
+    type: 'section',
+    fields: [
+      { type: 'mrkdwn', text: `*Level*\n${displayValue(player.level)}` },
+      { type: 'mrkdwn', text: `*XP*\n${displayValue(player.xp)}` },
+      { type: 'mrkdwn', text: `*HP*\n${hpText}` },
+      { type: 'mrkdwn', text: `*Gold*\n${displayValue(player.gold)}` },
+      { type: 'mrkdwn', text: `*Skill Points*\n${displayValue(skillPoints)}` },
+      {
+        type: 'mrkdwn',
+        text: `*Location*\n${displayValue(player.x)}/${displayValue(player.y)}`,
+      },
+    ],
+  });
+
+  blocks.push({
+    type: 'section',
+    fields: [
+      {
+        type: 'mrkdwn',
+        text: `*Strength*\n${attributeWithModifier(player.strength)}`,
+      },
+      {
+        type: 'mrkdwn',
+        text: `*Agility*\n${attributeWithModifier(player.agility)}`,
+      },
+      {
+        type: 'mrkdwn',
+        text: `*Vitality*\n${attributeWithModifier(player.health)}`,
+      },
+    ],
+  });
+
+  if (typeof player.level === 'number' && typeof player.xp === 'number') {
+    const xpForNextLevel = player.level * 100;
+    const xpNeeded = Math.max(0, xpForNextLevel - player.xp);
+    blocks.push({
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text:
+            xpNeeded > 0
+              ? `🏅 ${xpNeeded} XP needed for level ${player.level + 1}.`
+              : `🏅 You have enough XP to reach the next level!`,
+        },
+      ],
+    });
+  }
+
+  if (options.isSelf) {
+    blocks.push(...buildActionsBlock(skillPoints));
+  }
+
+  return {
+    text: `${title} — HP ${hpText}`,
+    blocks,
+  };
 }
 
-export function formatMonsterStats(monster: MonsterStatsSource): string {
-  return (
-    `*Monster Stats*\n` +
-    `- Name: ${displayValue(monster.name)}\n` +
-    `- Type: ${displayValue(monster.type)}\n` +
-    `- Strength: ${displayValue(monster.strength)}\n` +
-    `- Agility: ${displayValue(monster.agility)}\n` +
-    `- Health: ${displayValue(monster.health)}\n` +
-    `- HP: ${displayValue(monster.hp)}/${displayValue(monster.maxHp)}\n` +
-    `- Status: ${monster.isAlive ? 'Alive' : 'Defeated'}\n` +
-    `- Position: ${displayValue(monster.x)}/${displayValue(monster.y)}`
-  );
+export function buildMonsterStatsMessage(monster: MonsterStatsSource): SayMessage {
+  const name = displayValue(monster.name);
+  const hpText = `${displayValue(monster.hp)}/${displayValue(monster.maxHp)}`;
+  const blocks: (KnownBlock | Block)[] = [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: `${name} (Monster)`, emoji: true },
+    },
+    {
+      type: 'section',
+      fields: [
+        { type: 'mrkdwn', text: `*Type*\n${displayValue(monster.type)}` },
+        { type: 'mrkdwn', text: `*HP*\n${hpText}` },
+        {
+          type: 'mrkdwn',
+          text: `*Status*\n${monster.isAlive ? 'Alive' : 'Defeated'}`,
+        },
+        {
+          type: 'mrkdwn',
+          text: `*Strength*\n${attributeWithModifier(monster.strength)}`,
+        },
+        {
+          type: 'mrkdwn',
+          text: `*Agility*\n${attributeWithModifier(monster.agility)}`,
+        },
+        {
+          type: 'mrkdwn',
+          text: `*Vitality*\n${attributeWithModifier(monster.health)}`,
+        },
+      ],
+    },
+    {
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: `📍 Location: ${displayValue(monster.x)}/${displayValue(monster.y)}`,
+        },
+      ],
+    },
+  ];
+
+  return {
+    text: `${name} — HP ${hpText}`,
+    blocks,
+  };
 }

--- a/apps/world/src/world/models/player.model.ts
+++ b/apps/world/src/world/models/player.model.ts
@@ -42,6 +42,9 @@ export class Player {
   @Field(() => Int)
   level!: number;
 
+  @Field(() => Int)
+  skillPoints!: number;
+
   @Field()
   isAlive!: boolean;
 

--- a/dm-schema.gql
+++ b/dm-schema.gql
@@ -51,6 +51,7 @@ type Player {
   gold: Int!
   xp: Int!
   level: Int!
+  skillPoints: Int!
   isAlive: Boolean!
   lastAction: DateTime
   createdAt: DateTime
@@ -291,6 +292,7 @@ type Query {
 type Mutation {
   createPlayer(input: CreatePlayerInput!): PlayerResponse!
   updatePlayerStats(slackId: String!, input: PlayerStatsInput!): PlayerResponse!
+  spendSkillPoint(slackId: String!, attribute: PlayerAttribute!): PlayerResponse!
   rerollPlayerStats(slackId: String!): PlayerResponse!
   healPlayer(slackId: String!, amount: Float!): PlayerResponse!
   damagePlayer(slackId: String!, damage: Float!): PlayerResponse!
@@ -342,6 +344,12 @@ enum Direction {
   EAST
   SOUTH
   WEST
+}
+
+enum PlayerAttribute {
+  STRENGTH
+  AGILITY
+  HEALTH
 }
 
 input SpawnMonsterInput {

--- a/libs/database/package.json
+++ b/libs/database/package.json
@@ -13,7 +13,7 @@
     }
   },
   "dependencies": {
-    "@prisma/client": "latest",
+    "@prisma/client": "6.16.2",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/libs/database/prisma/migrations/20250901000000_add_skill_points/migration.sql
+++ b/libs/database/prisma/migrations/20250901000000_add_skill_points/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Player" ADD COLUMN     "skillPoints" INTEGER NOT NULL DEFAULT 0;

--- a/libs/database/prisma/schema.prisma
+++ b/libs/database/prisma/schema.prisma
@@ -33,6 +33,7 @@ model Player {
   gold        Int        @default(0)
   xp          Int        @default(0)
   level       Int        @default(1)
+  skillPoints Int        @default(0)
   isAlive     Boolean    @default(true)
   lastAction  DateTime   @default(now())
   createdAt   DateTime   @default(now())

--- a/yarn.lock
+++ b/yarn.lock
@@ -2064,7 +2064,7 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@prisma/client@latest":
+"@prisma/client@6.16.2":
   version "6.16.2"
   resolved "https://registry.yarnpkg.com/@prisma/client/-/client-6.16.2.tgz#db11b9af568d1761c0b712fccfc6ee484d2310d7"
   integrity sha512-E00PxBcalMfYO/TWnXobBVUai6eW/g5OsifWQsQDzJYm7yaY+IRLo7ZLsaefi0QkTpxfuhFcQ/w180i6kX3iJw==


### PR DESCRIPTION
## Summary
- add persistent skill point tracking to the player model and migrations
- implement automatic level up handling with HP growth and periodic skill point awards
- enhance Slack stats blocks with tables and upgrade buttons tied to the new spendSkillPoint mutation

## Testing
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68ddb9a22010833099d6931e639ae431