### PR TITLE
feat(slack-bot): show top 10 leaderboard on home tab

### DIFF
--- a/apps/slack-bot/src/generated/dm-graphql.ts
+++ b/apps/slack-bot/src/generated/dm-graphql.ts
@@ -520,6 +520,11 @@ export type GetLocationEntitiesQueryVariables = Exact<{
 
 export type GetLocationEntitiesQuery = { __typename?: 'Query', getPlayersAtLocation: Array<{ __typename?: 'Player', id: string, slackId: string, name: string, x: number, y: number, hp: number, maxHp: number, strength: number, agility: number, health: number, gold: number, xp: number, level: number, skillPoints: number, isAlive: boolean }>, getMonstersAtLocation: Array<{ __typename?: 'Monster', id: string, name: string, type: string, hp: number, maxHp: number, strength: number, agility: number, health: number, x: number, y: number, isAlive: boolean }> };
 
+export type GetAllPlayersQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetAllPlayersQuery = { __typename?: 'Query', getAllPlayers: Array<{ __typename?: 'Player', id: string, slackId: string, name: string, level: number, xp: number, isAlive: boolean }> };
+
 export type GetPlayerWithLocationQueryVariables = Exact<{
   slackId: Scalars['String']['input'];
 }>;
@@ -675,6 +680,18 @@ export const GetLocationEntitiesDocument = gql`
     health
     x
     y
+    isAlive
+  }
+}
+    `;
+export const GetAllPlayersDocument = gql`
+    query GetAllPlayers {
+  getAllPlayers {
+    id
+    slackId
+    name
+    level
+    xp
     isAlive
   }
 }
@@ -896,6 +913,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     GetLocationEntities(variables: GetLocationEntitiesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<GetLocationEntitiesQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetLocationEntitiesQuery>({ document: GetLocationEntitiesDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'GetLocationEntities', 'query', variables);
+    },
+    GetAllPlayers(variables?: GetAllPlayersQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<GetAllPlayersQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetAllPlayersQuery>({ document: GetAllPlayersDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'GetAllPlayers', 'query', variables);
     },
     GetPlayerWithLocation(variables: GetPlayerWithLocationQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<GetPlayerWithLocationQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetPlayerWithLocationQuery>({ document: GetPlayerWithLocationDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'GetPlayerWithLocation', 'query', variables);

--- a/apps/slack-bot/src/graphql/dm.graphql
+++ b/apps/slack-bot/src/graphql/dm.graphql
@@ -102,6 +102,17 @@ query GetLocationEntities($x: Float!, $y: Float!) {
   }
 }
 
+query GetAllPlayers {
+  getAllPlayers {
+    id
+    slackId
+    name
+    level
+    xp
+    isAlive
+  }
+}
+
 query GetPlayerWithLocation($slackId: String!) {
   getPlayer(slackId: $slackId) {
     success

--- a/apps/slack-bot/src/handlers/appHome.spec.ts
+++ b/apps/slack-bot/src/handlers/appHome.spec.ts
@@ -1,5 +1,43 @@
 import type { App } from '@slack/bolt';
+import { dmSdk } from '../gql-client';
 import { buildAppHomeBlocks, registerAppHome } from './appHome';
+
+jest.mock('../gql-client', () => ({
+  dmSdk: {
+    GetAllPlayers: jest.fn(),
+  },
+}));
+
+const mockGetAllPlayers = dmSdk.GetAllPlayers as jest.Mock;
+
+const sampleLeaderboard = [
+  {
+    __typename: 'Player' as const,
+    id: '1',
+    slackId: 'U1',
+    name: 'Aria',
+    level: 5,
+    xp: 420,
+    isAlive: true,
+  },
+  {
+    __typename: 'Player' as const,
+    id: '2',
+    slackId: 'U2',
+    name: 'Borin',
+    level: 4,
+    xp: 350,
+    isAlive: false,
+  },
+];
+
+beforeEach(() => {
+  mockGetAllPlayers.mockResolvedValue({ getAllPlayers: sampleLeaderboard });
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
 
 type AppHomeHandler = (args: {
   event: { user: string };
@@ -32,6 +70,26 @@ describe('buildAppHomeBlocks', () => {
         })
         .join(' ');
       expect(text).toEqual(expect.stringContaining('Need a refresher'));
+    }
+  });
+
+  it('renders leaderboard when entries are provided', () => {
+    const blocks = buildAppHomeBlocks({ leaderboard: sampleLeaderboard });
+    const leaderboardSection = blocks.find(
+      (block) => block.type === 'section' &&
+        'text' in block &&
+        block.text?.type === 'mrkdwn' &&
+        block.text.text.includes('Workspace Leaderboard'),
+    );
+
+    expect(leaderboardSection).toBeDefined();
+    if (leaderboardSection && 'text' in leaderboardSection && leaderboardSection.text) {
+      expect(leaderboardSection.text).toMatchObject({
+        text: expect.stringContaining('1. *Aria* — Level 5 · 420 XP'),
+      });
+      expect(leaderboardSection.text).toMatchObject({
+        text: expect.stringContaining('2. *Borin* — Level 4 · 350 XP ☠️'),
+      });
     }
   });
 });
@@ -70,6 +128,7 @@ describe('registerAppHome', () => {
       }),
     );
     expect(logger.error).not.toHaveBeenCalled();
+    expect(mockGetAllPlayers).toHaveBeenCalledTimes(1);
   });
 
   it('logs an error when publishing fails', async () => {
@@ -97,5 +156,35 @@ describe('registerAppHome', () => {
       'Failed to publish App Home',
       expect.any(Error),
     );
+  });
+
+  it('logs a leaderboard error but still publishes the view', async () => {
+    mockGetAllPlayers.mockRejectedValueOnce(new Error('network error'));
+    const handlers: Record<string, AppHomeHandler> = {};
+    const views = { publish: jest.fn().mockResolvedValue(undefined) };
+    const logger = { error: jest.fn() };
+    const app = {
+      event: jest.fn((eventName: string, handler: AppHomeHandler) => {
+        handlers[eventName] = handler;
+      }),
+    } as unknown as App;
+
+    registerAppHome(app);
+    const handler = handlers.app_home_opened;
+    if (!handler) {
+      throw new Error('app_home_opened handler was not registered');
+    }
+
+    await handler({
+      event: { user: 'U111' },
+      client: { views },
+      logger,
+    });
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Failed to load leaderboard',
+      expect.any(Error),
+    );
+    expect(views.publish).toHaveBeenCalled();
   });
 });

--- a/apps/slack-bot/src/handlers/appHome.ts
+++ b/apps/slack-bot/src/handlers/appHome.ts
@@ -1,10 +1,35 @@
 import { App } from '@slack/bolt';
 import type { KnownBlock } from '@slack/types';
 import { COMMANDS } from '../commands';
+import { dmSdk } from '../gql-client';
+import type { GetAllPlayersQuery } from '../generated/dm-graphql';
 import { buildHelpBlocks } from './help';
 
-export const buildAppHomeBlocks = (): KnownBlock[] => {
+type LeaderboardPlayer = GetAllPlayersQuery['getAllPlayers'][number];
+
+const MAX_LEADERBOARD_ENTRIES = 10;
+
+function formatLeaderboardLine(player: LeaderboardPlayer, index: number): string {
+  const rank = index + 1;
+  const xpText = typeof player.xp === 'number' ? ` · ${player.xp} XP` : '';
+  const status = player.isAlive ? '' : ' ☠️';
+  return `${rank}. *${player.name}* — Level ${player.level}${xpText}${status}`;
+}
+
+function buildLeaderboardText(leaderboard: LeaderboardPlayer[]): string {
+  if (leaderboard.length === 0) {
+    return '_No adventurers have stepped forward yet. Be the first to create your character!_';
+  }
+
+  return leaderboard.map(formatLeaderboardLine).join('\n');
+}
+
+export const buildAppHomeBlocks = (options: {
+  leaderboard?: LeaderboardPlayer[];
+} = {}): KnownBlock[] => {
   const helpBlocks = buildHelpBlocks();
+  const leaderboard = options.leaderboard ?? [];
+  const leaderboardText = buildLeaderboardText(leaderboard);
   return [
     {
       type: 'header',
@@ -35,8 +60,17 @@ export const buildAppHomeBlocks = (): KnownBlock[] => {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: '*🏆 Workspace Leaderboard*\n_Coming soon: see which adventurers are leading the charge in your workspace._',
+        text: `*🏆 Workspace Leaderboard*\n${leaderboardText}`,
       },
+    },
+    {
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: `Top ${Math.min(leaderboard.length || MAX_LEADERBOARD_ENTRIES, MAX_LEADERBOARD_ENTRIES)} ranked by level, then XP.`,
+        },
+      ],
     },
     {
       type: 'section',
@@ -52,13 +86,31 @@ export const buildAppHomeBlocks = (): KnownBlock[] => {
 
 export const registerAppHome = (app: App) => {
   app.event('app_home_opened', async ({ event, client, logger }) => {
+    let leaderboard: LeaderboardPlayer[] = [];
+    try {
+      const result = await dmSdk.GetAllPlayers();
+      leaderboard = [...result.getAllPlayers]
+        .sort((a, b) => {
+          if (b.level !== a.level) {
+            return b.level - a.level;
+          }
+          if (b.xp !== a.xp) {
+            return b.xp - a.xp;
+          }
+          return a.name.localeCompare(b.name);
+        })
+        .slice(0, MAX_LEADERBOARD_ENTRIES);
+    } catch (error) {
+      logger.error('Failed to load leaderboard', error);
+    }
+
     try {
       await client.views.publish({
         user_id: event.user,
         view: {
           type: 'home',
           callback_id: 'home_view',
-          blocks: buildAppHomeBlocks(),
+          blocks: buildAppHomeBlocks({ leaderboard }),
         },
       });
     } catch (error) {


### PR DESCRIPTION
## Summary
- fetch all players when the Slack App Home loads and build a top-10 leaderboard ordered by level and XP
- render the leaderboard in the Home tab with helpful context while preserving existing help content
- add tests covering leaderboard formatting, successful publishing, and error handling

## Testing
- yarn --cwd apps/slack-bot test

------
https://chatgpt.com/codex/tasks/task_e_68dec4cf51608330afc374ced4538bf7