### PR TITLE
Fix monster service test filtering

### DIFF
--- a/apps/dm/src/app/monster/monster.service.spec.ts
+++ b/apps/dm/src/app/monster/monster.service.spec.ts
@@ -34,7 +34,7 @@ jest.mock('@mud/database', () => ({
           }
         }
         if (where.isAlive !== undefined) {
-          result = monsters.filter((m) => m.isAlive === where.isAlive);
+          result = result.filter((m) => m.isAlive === where.isAlive);
         }
         if (args.include?.biome) {
           return result.map((m) => ({ ...m, biome: { name: 'forest' } }));


### PR DESCRIPTION
## Summary
- ensure the monster service test double respects other filters when applying `isAlive`

## Testing
- yarn turbo run test --filter=@mud/dm

------
https://chatgpt.com/codex/tasks/task_e_68e1813b334c8330a9c89daf480467c0