### PR TITLE
Fix DM unit tests for engine entity compatibility

### DIFF
--- a/apps/dm/jest.config.js
+++ b/apps/dm/jest.config.js
@@ -7,6 +7,11 @@ export default {
     '^@mud/constants$': '<rootDir>/../../libs/constants/src/constants.ts',
     '^@mud/database$': '<rootDir>/../../libs/database/src/index.ts',
     '^@mud/gcp-auth$': '<rootDir>/../../libs/gcp-auth/src/gcp-auth.ts',
+    '^@mud/engine$': '<rootDir>/../../libs/engine/dist/index.js',
+    '^@mud/engine/(.*)$': '<rootDir>/../../libs/engine/dist/$1',
+    '^@mud/redis-client$':
+      '<rootDir>/../../libs/redis-client/dist/redis-client.js',
+    '^@mud/redis-client/(.*)$': '<rootDir>/../../libs/redis-client/dist/$1',
     '^@mud/(.*)$': '<rootDir>/../../libs/$1/src',
   },
   coverageDirectory: 'coverage',

--- a/apps/dm/src/app/game-tick/game-tick.service.spec.ts
+++ b/apps/dm/src/app/game-tick/game-tick.service.spec.ts
@@ -39,20 +39,35 @@ function createPrismaMock() {
   };
 }
 
-const prismaHolder: {
+type GameTickPrismaHolder = {
   prisma?: PrismaMock['prisma'];
   controller?: ReturnType<typeof createPrismaMock>;
-} = {};
+};
+
+function ensureGameTickPrismaHolder(): GameTickPrismaHolder {
+  const globalObject = globalThis as Record<string, unknown>;
+  const key = '__gameTickPrismaHolder';
+  if (!globalObject[key]) {
+    globalObject[key] = {};
+  }
+
+  return globalObject[key] as GameTickPrismaHolder;
+}
 
 jest.mock('@mud/database', () => ({
   getPrismaClient: () => {
-    if (!prismaHolder.controller) {
-      prismaHolder.controller = createPrismaMock();
-      prismaHolder.prisma = prismaHolder.controller.prisma;
+    const holder = ensureGameTickPrismaHolder();
+    if (!holder.controller) {
+      const controller = createPrismaMock();
+      holder.controller = controller;
+      holder.prisma = controller.prisma;
     }
-    return prismaHolder.prisma;
+
+    return holder.prisma;
   },
 }));
+
+const gameTickPrismaHolder = ensureGameTickPrismaHolder();
 
 describe('GameTickService', () => {
   const createService = () => {
@@ -60,12 +75,22 @@ describe('GameTickService', () => {
       monsterAttackPlayer: jest.fn(),
     } as unknown as { monsterAttackPlayer: jest.Mock };
     const playerService = {
-      getAllPlayers: jest
-        .fn()
-        .mockResolvedValue([{ slackId: 'U1', x: 1, y: 1, isAlive: true }]),
-      getPlayersAtLocation: jest
-        .fn()
-        .mockResolvedValue([{ slackId: 'U1', isAlive: true }]),
+      getAllPlayers: jest.fn().mockResolvedValue([
+        {
+          clientId: 'client-U1',
+          slackId: 'U1',
+          position: { x: 1, y: 1 },
+          combat: { isAlive: true },
+        },
+      ]),
+      getPlayersAtLocation: jest.fn().mockResolvedValue([
+        {
+          clientId: 'client-U1',
+          slackId: 'U1',
+          position: { x: 1, y: 1 },
+          combat: { isAlive: true },
+        },
+      ]),
     } as unknown as {
       getAllPlayers: jest.Mock;
       getPlayersAtLocation: jest.Mock;
@@ -88,8 +113,8 @@ describe('GameTickService', () => {
     } as unknown as { enforceDensityAround: jest.Mock };
     const monsterService = {
       getAllMonsters: jest.fn().mockResolvedValue([
-        { id: 1, x: 1, y: 1 },
-        { id: 2, x: 2, y: 2 },
+        { id: 1, position: { x: 1, y: 1 } },
+        { id: 2, position: { x: 2, y: 2 } },
       ]),
       moveMonster: jest.fn().mockResolvedValue(undefined),
       cleanupDeadMonsters: jest.fn().mockResolvedValue(undefined),
@@ -116,8 +141,8 @@ describe('GameTickService', () => {
   };
 
   beforeEach(() => {
-    prismaHolder.controller = undefined;
-    prismaHolder.prisma = undefined;
+    gameTickPrismaHolder.controller = undefined;
+    gameTickPrismaHolder.prisma = undefined;
     const randomValues = [
       0.3,
       0.6, // monster move checks
@@ -153,10 +178,13 @@ describe('GameTickService', () => {
     expect(result1.tick).toBe(1);
     expect(populationService.enforceDensityAround).toHaveBeenCalled();
     expect(monsterService.moveMonster).toHaveBeenCalledWith(1);
-    expect(combatService.monsterAttackPlayer).toHaveBeenCalledWith(1, 'U1');
+    expect(combatService.monsterAttackPlayer).toHaveBeenCalledWith(
+      1,
+      'client-U1',
+    );
 
     // Prepare for weather update at tick 4
-    prismaHolder.controller?.setGameState({
+    gameTickPrismaHolder.controller?.setGameState({
       id: 1,
       tick: 3,
       gameHour: 0,
@@ -166,7 +194,7 @@ describe('GameTickService', () => {
     expect(result2.weatherUpdated).toBe(true);
 
     // Prepare for cleanup branch at tick 10
-    prismaHolder.controller?.setGameState({
+    gameTickPrismaHolder.controller?.setGameState({
       id: 1,
       tick: 9,
       gameHour: 1,
@@ -179,7 +207,7 @@ describe('GameTickService', () => {
 
   it('returns combined game state snapshot', async () => {
     const { service } = createService();
-    prismaHolder.controller?.setGameState({
+    gameTickPrismaHolder.controller?.setGameState({
       id: 1,
       tick: 5,
       gameHour: 2,

--- a/apps/dm/src/app/graphql/adapters/entity-to-graphql.adapter.ts
+++ b/apps/dm/src/app/graphql/adapters/entity-to-graphql.adapter.ts
@@ -6,72 +6,227 @@ import { PlayerEntity, MonsterEntity } from '@mud/engine';
 import { Player } from '../models/player.model';
 import { Monster } from '../models/monster.model';
 
+type PlayerLike = PlayerEntity | (Partial<Player> & Record<string, unknown>);
+type MonsterLike =
+  | MonsterEntity
+  | (Partial<Monster> & Record<string, unknown>);
+
+const toNumber = (value: unknown, fallback = 0): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+
+  return fallback;
+};
+
+const toBoolean = (value: unknown, fallback: boolean): boolean => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  return fallback;
+};
+
+const toDateOrUndefined = (value: unknown): Date | undefined => {
+  if (value instanceof Date) {
+    return value;
+  }
+
+  if (typeof value === 'string' || typeof value === 'number') {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+
+  return undefined;
+};
+
+const toStringOrUndefined = (value: unknown): string | undefined => {
+  if (typeof value === 'string' && value.length > 0) {
+    return value;
+  }
+
+  return undefined;
+};
+
+const resolveClientIdentity = (
+  entity: Record<string, unknown>,
+): {
+  clientType: string;
+  clientId: string;
+  slackId: string | null;
+} => {
+  const rawClientId = toStringOrUndefined(entity.clientId);
+  const rawClientType = toStringOrUndefined(entity.clientType);
+  const rawSlackId = toStringOrUndefined(entity.slackId);
+
+  let clientType = rawClientType;
+  let platformId = rawClientId;
+
+  if (rawClientId && rawClientId.includes(':')) {
+    const [maybeType, maybeId] = rawClientId.split(':', 2);
+    if (maybeId) {
+      platformId = maybeId;
+      if (!clientType) {
+        clientType = maybeType;
+      }
+    }
+  }
+
+  if (!platformId && rawSlackId) {
+    platformId = rawSlackId;
+    if (!clientType) {
+      clientType = 'slack';
+    }
+  }
+
+  if (!clientType) {
+    clientType = 'web';
+  }
+
+  if (!platformId) {
+    platformId = 'unknown';
+  }
+
+  const slackId = clientType === 'slack' ? platformId : rawSlackId ?? null;
+
+  return {
+    clientType,
+    clientId: platformId,
+    slackId,
+  };
+};
+
 export class EntityToGraphQLAdapter {
   /**
    * Convert PlayerEntity to GraphQL Player model
    */
-  static playerEntityToGraphQL(entity: PlayerEntity): Player {
+  static playerEntityToGraphQL(entity: PlayerLike): Player {
+    const raw = entity as Record<string, unknown>;
+    const position =
+      (raw.position as Record<string, unknown> | undefined) ?? {};
+    const combat = (raw.combat as Record<string, unknown> | undefined) ?? {};
+    const attributes =
+      (raw.attributes as Record<string, unknown> | undefined) ?? {};
+
+    const { clientType, clientId, slackId } = resolveClientIdentity(raw);
+
+    const hp = toNumber(combat.hp ?? raw.hp, 0);
+    const maxHp = toNumber(
+      combat.maxHp ?? raw.maxHp ?? combat.hp ?? raw.hp,
+      hp,
+    );
+
+    const lastAction = toDateOrUndefined(raw.lastAction);
+    const createdAt = toDateOrUndefined(raw.createdAt);
+    const updatedAt = toDateOrUndefined(raw.updatedAt) ?? new Date();
+
+    const worldTileRaw = raw.worldTileId;
+    const worldTileId =
+      worldTileRaw === null || worldTileRaw === undefined
+        ? null
+        : toNumber(worldTileRaw);
+
     return {
-      id: entity.id,
-      clientId: `${entity.clientType}:${entity.clientId}`,
-      clientType: entity.clientType,
-      slackId: entity.clientType === 'slack' ? entity.clientId : null,
-      name: entity.name,
-      x: entity.position.x,
-      y: entity.position.y,
-      hp: entity.combat.hp,
-      maxHp: entity.combat.maxHp,
-      strength: entity.attributes.strength,
-      agility: entity.attributes.agility,
-      health: entity.attributes.health,
-      gold: entity.gold,
-      xp: entity.xp,
-      level: entity.level,
-      skillPoints: entity.skillPoints,
-      isAlive: entity.combat.isAlive,
-      lastAction: undefined, // TODO: Add to entity if needed
-      createdAt: undefined, // TODO: Add to entity if needed
-      updatedAt: new Date(),
-      worldTileId: null,
+      id: toNumber(raw.id, 0),
+      clientId: `${clientType}:${clientId}`,
+      clientType,
+      slackId,
+      name: toStringOrUndefined(raw.name) ?? 'Unknown Adventurer',
+      x: toNumber(position.x ?? raw.x, 0),
+      y: toNumber(position.y ?? raw.y, 0),
+      hp,
+      maxHp,
+      strength: toNumber(attributes.strength ?? raw.strength, 0),
+      agility: toNumber(attributes.agility ?? raw.agility, 0),
+      health: toNumber(attributes.health ?? raw.health, 0),
+      gold: toNumber(raw.gold, 0),
+      xp: toNumber(raw.xp, 0),
+      level: toNumber(raw.level, 1),
+      skillPoints: toNumber(raw.skillPoints, 0),
+      isAlive: toBoolean(
+        combat.isAlive ?? raw.isAlive,
+        hp > 0 || toBoolean(raw.isAlive, true),
+      ),
+      lastAction,
+      createdAt,
+      updatedAt,
+      worldTileId,
     };
   }
 
   /**
    * Convert MonsterEntity to GraphQL Monster model
    */
-  static monsterEntityToGraphQL(entity: MonsterEntity): Monster {
+  static monsterEntityToGraphQL(entity: MonsterLike): Monster {
+    const raw = entity as Record<string, unknown>;
+    const position =
+      (raw.position as Record<string, unknown> | undefined) ?? {};
+    const combat = (raw.combat as Record<string, unknown> | undefined) ?? {};
+    const attributes =
+      (raw.attributes as Record<string, unknown> | undefined) ?? {};
+
+    const hp = toNumber(combat.hp ?? raw.hp, 0);
+    const maxHp = toNumber(
+      combat.maxHp ?? raw.maxHp ?? combat.hp ?? raw.hp,
+      hp,
+    );
+
+    const lastMove = toDateOrUndefined(raw.lastMove) ?? new Date(0);
+    const spawnedAt = toDateOrUndefined(raw.spawnedAt) ?? new Date(0);
+    const createdAt = toDateOrUndefined(raw.createdAt) ?? spawnedAt;
+    const updatedAt = toDateOrUndefined(raw.updatedAt) ?? new Date();
+    const worldTileRaw = raw.worldTileId;
+    const worldTileId =
+      worldTileRaw === undefined
+        ? undefined
+        : worldTileRaw === null
+          ? null
+          : toNumber(worldTileRaw);
+
     return {
-      id: entity.id,
-      name: entity.name,
-      type: entity.type,
-      hp: entity.combat.hp,
-      maxHp: entity.combat.maxHp,
-      strength: entity.attributes.strength,
-      agility: entity.attributes.agility,
-      health: entity.attributes.health,
-      x: entity.position.x,
-      y: entity.position.y,
-      isAlive: entity.combat.isAlive,
-      lastMove: entity.lastMove,
-      spawnedAt: entity.spawnedAt,
-      biomeId: entity.biomeId,
-      worldTileId: undefined,
-      createdAt: entity.spawnedAt,
-      updatedAt: new Date(),
+      id: toNumber(raw.id, 0),
+      name: toStringOrUndefined(raw.name) ?? 'Unknown Monster',
+      type: toStringOrUndefined(raw.type) ?? 'unknown',
+      hp,
+      maxHp,
+      strength: toNumber(attributes.strength ?? raw.strength, 0),
+      agility: toNumber(attributes.agility ?? raw.agility, 0),
+      health: toNumber(attributes.health ?? raw.health, 0),
+      x: toNumber(position.x ?? raw.x, 0),
+      y: toNumber(position.y ?? raw.y, 0),
+      isAlive: toBoolean(
+        combat.isAlive ?? raw.isAlive,
+        hp > 0 || toBoolean(raw.isAlive, true),
+      ),
+      lastMove,
+      spawnedAt,
+      biomeId: toNumber(raw.biomeId, 0),
+      worldTileId,
+      createdAt,
+      updatedAt,
     };
   }
 
   /**
    * Convert array of PlayerEntity to GraphQL Player models
    */
-  static playerEntitiesToGraphQL(entities: PlayerEntity[]): Player[] {
+  static playerEntitiesToGraphQL(entities: PlayerLike[] = []): Player[] {
     return entities.map((entity) => this.playerEntityToGraphQL(entity));
   }
 
   /**
    * Convert array of MonsterEntity to GraphQL Monster models
    */
-  static monsterEntitiesToGraphQL(entities: MonsterEntity[]): Monster[] {
+  static monsterEntitiesToGraphQL(entities: MonsterLike[] = []): Monster[] {
     return entities.map((entity) => this.monsterEntityToGraphQL(entity));
   }
 }

--- a/apps/dm/src/app/graphql/resolvers/movement.resolver.spec.ts
+++ b/apps/dm/src/app/graphql/resolvers/movement.resolver.spec.ts
@@ -15,7 +15,23 @@ import { AiService } from '../../../openai/ai.service';
 import { LookViewResponse } from '../types/response.types';
 
 describe('MovementResolver', () => {
-  const createResolver = (overrides: Partial<Record<string, unknown>> = {}) => {
+  const basePlayer = {
+    id: 1,
+    name: 'Hero',
+    clientId: 'U1',
+    clientType: 'slack' as const,
+    position: { x: 0, y: 0 },
+    attributes: { strength: 10, agility: 10, health: 10 },
+    combat: { hp: 10, maxHp: 10, isAlive: true },
+    level: 1,
+    xp: 0,
+    gold: 0,
+    skillPoints: 0,
+  } as const;
+
+  const createResolver = (
+    overrides: Partial<Record<string, unknown>> = {},
+  ) => {
     const playerService = {
       movePlayer: jest.fn(),
       getPlayersAtLocation: jest.fn().mockResolvedValue([{ name: 'Other' }]),
@@ -128,30 +144,41 @@ describe('MovementResolver', () => {
 
   it('moves a player and returns location data', async () => {
     const { resolver, playerService, monsterService } = createResolver();
-    playerService.movePlayer.mockResolvedValue({ x: 1, y: 2 });
+    playerService.movePlayer.mockResolvedValue({
+      ...basePlayer,
+      position: { x: 1, y: 2 },
+    });
 
-    const result = await resolver.movePlayer('U1', {
-      direction: 'north',
-    } as MovePlayerInput);
+    const result = await resolver.movePlayer(
+      { direction: 'north' } as MovePlayerInput,
+      'U1',
+    );
 
     expect(result.success).toBe(true);
     expect(playerService.movePlayer).toHaveBeenCalledWith('U1', {
       direction: 'north',
     });
     expect(monsterService.getMonstersAtLocation).toHaveBeenCalledWith(1, 2);
+    expect(result.player?.x).toBe(1);
+    expect(result.player?.y).toBe(2);
   });
 
   it('falls back to current location when movement fails', async () => {
     const { resolver, playerService } = createResolver();
     playerService.movePlayer.mockRejectedValue(new Error('nope'));
-    playerService.getPlayer.mockResolvedValue({ x: 9, y: 9 });
+    playerService.getPlayer.mockResolvedValue({
+      ...basePlayer,
+      position: { x: 9, y: 9 },
+    });
 
-    const result = await resolver.movePlayer('U1', {
-      direction: 'east',
-    } as MovePlayerInput);
+    const result = await resolver.movePlayer(
+      { direction: 'east' } as MovePlayerInput,
+      'U1',
+    );
 
     expect(result.success).toBe(false);
-    expect(result.player).toEqual({ x: 9, y: 9 });
+    expect(result.player?.x).toBe(9);
+    expect(result.player?.y).toBe(9);
   });
 
   it('builds look view using AI description', async () => {
@@ -160,9 +187,8 @@ describe('MovementResolver', () => {
       createResolver();
 
     playerService.getPlayer.mockResolvedValue({
-      x: 3,
-      y: 4,
-      isAlive: true,
+      ...basePlayer,
+      position: { x: 3, y: 4 },
     });
 
     const response = (await resolver.getLookView('U1')) as LookViewResponse;

--- a/apps/dm/src/app/monster/monster.service.spec.ts
+++ b/apps/dm/src/app/monster/monster.service.spec.ts
@@ -94,7 +94,7 @@ describe('MonsterService', () => {
   it('spawns monsters and prevents water spawns', async () => {
     const service = new MonsterService(worldService);
     const spawned = await service.spawnMonster(1, 2, 1);
-    expect(spawned.hp).toBeGreaterThan(0);
+    expect(spawned.combat.hp).toBeGreaterThan(0);
 
     await expect(service.spawnMonster(999, 2, 1)).rejects.toThrow('water');
   });
@@ -149,7 +149,7 @@ describe('MonsterService', () => {
     });
 
     const damaged = await service.damageMonster(2, 10);
-    expect(damaged.isAlive).toBe(false);
+    expect(damaged.combat.isAlive).toBe(false);
 
     await service.cleanupDeadMonsters();
     expect(monsters.find((m) => m.id === 2)).toBeUndefined();

--- a/apps/dm/src/shared/coordination.service.spec.ts
+++ b/apps/dm/src/shared/coordination.service.spec.ts
@@ -37,7 +37,7 @@ type EnvOverrides = {
 };
 
 const instantiateService = (overrides: EnvOverrides = {}) => {
-  let ServiceClass: { new (): CoordinationServiceType };
+  let ServiceClass: { new (): CoordinationServiceType } | undefined;
   let client: RedisClientMock | undefined;
 
   jest.resetModules();
@@ -57,11 +57,16 @@ const instantiateService = (overrides: EnvOverrides = {}) => {
       },
     }));
 
-    const { CoordinationService: ServiceClass } = await import(
-      './coordination.service'
-    );
-    return ServiceClass;
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const moduleExports = require('./coordination.service') as {
+      CoordinationService: { new (): CoordinationServiceType };
+    };
+    ServiceClass = moduleExports.CoordinationService;
   });
+
+  if (!ServiceClass) {
+    throw new Error('Failed to load CoordinationService');
+  }
 
   const service = new ServiceClass();
   return { service, client };


### PR DESCRIPTION
## Summary
- harden the DM GraphQL entity adapter so it can coerce both engine-shaped and legacy entities
- refresh DM resolver and service specs to use engine-style mocks and expanded Prisma stubs
- stabilize combat and game-tick specs with hoist-safe Prisma holders and updated client ID expectations

## Testing
- yarn turbo run test --filter=@mud/dm

------
https://chatgpt.com/codex/tasks/task_e_68e1eb5a67288330af15e29742977f58