### PR TITLE
Fix Slack bot DM client IDs in actions and tests

### DIFF
--- a/apps/slack-bot/src/actions.spec.ts
+++ b/apps/slack-bot/src/actions.spec.ts
@@ -18,6 +18,7 @@ import { getAllHandlers } from './handlers/handlerRegistry';
 import { HandlerContext } from './handlers/types';
 import { dmSdk } from './gql-client';
 import { PlayerAttribute, TargetType } from './generated/dm-graphql';
+import { toClientId } from './utils/clientId';
 
 const mockedDmSdk = dmSdk as unknown as {
   Attack: jest.Mock;
@@ -329,7 +330,7 @@ describe('registerActions', () => {
 
     expect(ack).toHaveBeenCalled();
     expect(mockedDmSdk.Attack).toHaveBeenCalledWith({
-      slackId: 'U1',
+      slackId: toClientId('U1'),
       input: { targetType: TargetType.Monster, targetId: 42 },
     });
     expect(client.chat.postMessage).toHaveBeenCalledWith(
@@ -916,7 +917,7 @@ describe('registerActions', () => {
         message: null,
         data: {
           id: '1',
-          slackId: 'U1',
+          slackId: toClientId('U1'),
           name: 'Hero',
           hp: 18,
           maxHp: 18,
@@ -955,7 +956,7 @@ describe('registerActions', () => {
     });
 
     expect(mockedDmSdk.SpendSkillPoint).toHaveBeenCalledWith({
-      slackId: 'U1',
+      slackId: toClientId('U1'),
       attribute: PlayerAttribute.Strength,
     });
     expect(client.chat.update).toHaveBeenCalledWith(
@@ -995,7 +996,7 @@ describe('registerActions', () => {
     });
 
     expect(mockedDmSdk.SpendSkillPoint).toHaveBeenCalledWith({
-      slackId: 'U1',
+      slackId: toClientId('U1'),
       attribute: PlayerAttribute.Agility,
     });
     expect(client.chat.update).not.toHaveBeenCalled();

--- a/apps/slack-bot/src/actions.ts
+++ b/apps/slack-bot/src/actions.ts
@@ -16,6 +16,7 @@ import { getAllHandlers } from './handlers/handlerRegistry';
 import { buildPlayerStatsMessage } from './handlers/stats/format';
 import type { HandlerContext, SayMessage } from './handlers/types';
 import type { ViewStateValue } from '@slack/bolt';
+import { toClientId } from './utils/clientId';
 
 type SlackBlockState = Record<string, Record<string, ViewStateValue>>;
 
@@ -173,7 +174,7 @@ export function registerActions(app: App) {
 
     await ack();
 
-    const userId = body.user.id;
+    const userId = body.user?.id;
     if (!userId) return;
     const handler = getAllHandlers()[COMMANDS.NEW];
     if (!handler) return;
@@ -244,7 +245,7 @@ export function registerActions(app: App) {
 
     try {
       const attackResult = await dmSdk.Attack({
-        slackId: userId,
+        slackId: toClientId(userId),
         input: {
           targetType: TargetType.Monster,
           targetId: selected.id,
@@ -304,7 +305,7 @@ export function registerActions(app: App) {
 
       try {
         const result = await dmSdk.SpendSkillPoint({
-          slackId: userId,
+          slackId: toClientId(userId),
           attribute,
         });
         if (!result.spendSkillPoint.success || !result.spendSkillPoint.data) {

--- a/apps/slack-bot/src/handlers/commandHandlers.spec.ts
+++ b/apps/slack-bot/src/handlers/commandHandlers.spec.ts
@@ -29,6 +29,7 @@ import { moveHandler } from './move';
 import { rerollHandler } from './reroll';
 import { COMMANDS, ATTACK_ACTIONS } from '../commands';
 import type { HandlerContext, SayMessage } from './types';
+import { toClientId } from '../utils/clientId';
 
 const mockedDmSdk = dmSdk as unknown as {
   Attack: jest.Mock;
@@ -83,7 +84,7 @@ beforeEach(() => {
       success: true,
       data: {
         id: '1',
-        slackId: 'U1',
+        slackId: toClientId('U1'),
         name: 'Hero',
         hp: 1,
         maxHp: 10,
@@ -125,7 +126,7 @@ describe('attackHandler', () => {
     } as HandlerContext);
 
     expect(mockedDmSdk.Attack).toHaveBeenCalledWith({
-      slackId: 'U1',
+      slackId: toClientId('U1'),
       input: {
         targetType: TargetType.Player,
         targetSlackId: 'U2',
@@ -296,7 +297,7 @@ describe('createHandler', () => {
     } as HandlerContext);
 
     expect(mockedDmSdk.CreatePlayer).toHaveBeenCalledWith({
-      input: { slackId: 'U1', name: 'Hero' },
+      input: { slackId: toClientId('U1'), name: 'Hero' },
     });
     expect(say).toHaveBeenLastCalledWith(
       expect.objectContaining({
@@ -444,7 +445,9 @@ describe('deleteHandler', () => {
 
     await deleteHandler({ userId: 'U1', text: '', say } as HandlerContext);
 
-    expect(mockedDmSdk.DeletePlayer).toHaveBeenCalledWith({ slackId: 'U1' });
+    expect(mockedDmSdk.DeletePlayer).toHaveBeenCalledWith({
+      slackId: toClientId('U1'),
+    });
     expect(say).toHaveBeenCalledWith(
       expect.objectContaining({
         text: expect.stringContaining('has been successfully deleted'),
@@ -624,7 +627,7 @@ describe('moveHandler', () => {
     } as HandlerContext);
 
     expect(mockedDmSdk.MovePlayer).toHaveBeenCalledWith({
-      slackId: 'U1',
+      slackId: toClientId('U1'),
       input: { direction: Direction.North },
     });
     expect(mockedSendPngMap).toHaveBeenCalledWith(say, 1, 2, 8);
@@ -657,7 +660,7 @@ describe('moveHandler', () => {
     } as HandlerContext);
 
     expect(mockedDmSdk.MovePlayer).toHaveBeenCalledWith({
-      slackId: 'U1',
+      slackId: toClientId('U1'),
       input: { x: 10, y: -5 },
     });
     expect(say).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary
- ensure Slack action handlers convert Slack IDs to the client ID format before calling the DM service
- guard create-character modal submission against missing user context and update tests to match prefixed IDs

## Testing
- yarn turbo run test --filter=@mud/slack-bot

------
https://chatgpt.com/codex/tasks/task_e_68e1f4a43ae48330a0d1f943031aee5d