### PR TITLE
Notify players on respawn

### DIFF
--- a/apps/dm/jest.config.js
+++ b/apps/dm/jest.config.js
@@ -1,6 +1,19 @@
 import baseConfig from '../../jest.base.config.cjs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 export default {
   ...baseConfig,
   displayName: '@mud/dm',
+  moduleNameMapper: {
+    ...(baseConfig.moduleNameMapper ?? {}),
+    '^@mud/engine$': path.resolve(__dirname, '../../libs/engine/dist/index.js'),
+    '^@mud/redis-client$': path.resolve(
+      __dirname,
+      '../../libs/redis-client/dist/redis-client.js',
+    ),
+  },
 };

--- a/apps/dm/src/app/app.module.ts
+++ b/apps/dm/src/app/app.module.ts
@@ -24,6 +24,7 @@ import {
 } from './graphql/services';
 import { PopulationService } from './monster/population.service';
 import { PrefetchService } from './prefetch/prefetch.service';
+import { PlayerNotificationService } from './player/player-notification.service';
 import { LoggingInterceptor } from './interceptors/logging.interceptor';
 
 @Module({
@@ -56,6 +57,7 @@ import { LoggingInterceptor } from './interceptors/logging.interceptor';
     ResponseService,
     PopulationService,
     PrefetchService,
+    PlayerNotificationService,
     {
       provide: APP_INTERCEPTOR,
       useClass: LoggingInterceptor,

--- a/apps/dm/src/app/player/player-notification.service.spec.ts
+++ b/apps/dm/src/app/player/player-notification.service.spec.ts
@@ -1,0 +1,98 @@
+import { Logger } from '@nestjs/common';
+import { EventBus, type PlayerRespawnEvent } from '@mud/engine';
+import { EventBridgeService } from '../../shared/event-bridge.service';
+import { PlayerNotificationService } from './player-notification.service';
+
+jest.mock('@mud/engine', () => ({
+  EventBus: {
+    on: jest.fn(),
+  },
+}));
+
+describe('PlayerNotificationService', () => {
+  let service: PlayerNotificationService;
+  let eventBridge: { publishPlayerNotification: jest.Mock };
+  let listener: ((event: PlayerRespawnEvent) => Promise<void> | void) | null;
+
+  beforeEach(() => {
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+
+    eventBridge = {
+      publishPlayerNotification: jest.fn().mockResolvedValue(undefined),
+    };
+
+    listener = null;
+    (EventBus.on as jest.Mock).mockImplementation((eventType, callback) => {
+      if (eventType === 'player:respawn') {
+        listener = callback as (event: PlayerRespawnEvent) => Promise<void>;
+      }
+      return jest.fn();
+    });
+
+    service = new PlayerNotificationService(
+      eventBridge as unknown as EventBridgeService,
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+  });
+
+  it('subscribes to player respawn events on init', () => {
+    service.onModuleInit();
+    expect(EventBus.on).toHaveBeenCalledWith(
+      'player:respawn',
+      expect.any(Function),
+    );
+  });
+
+  it('publishes a player notification when a respawn event has a Slack ID', async () => {
+    service.onModuleInit();
+    const event: PlayerRespawnEvent = {
+      eventType: 'player:respawn',
+      timestamp: new Date(),
+      player: {
+        id: 1,
+        name: 'Test Player',
+        slackId: 'U123',
+      } as unknown as PlayerRespawnEvent['player'],
+      x: 10,
+      y: 20,
+    };
+
+    await listener?.(event);
+
+    expect(eventBridge.publishPlayerNotification).toHaveBeenCalledWith(
+      event,
+      expect.arrayContaining([
+        expect.objectContaining({
+          clientType: 'slack',
+          clientId: 'slack:U123',
+          message: expect.stringContaining('respawned'),
+        }),
+      ]),
+    );
+  });
+
+  it('does not publish notification when Slack ID is missing', async () => {
+    service.onModuleInit();
+    const event: PlayerRespawnEvent = {
+      eventType: 'player:respawn',
+      timestamp: new Date(),
+      player: {
+        id: 2,
+        name: 'No Slack',
+        slackId: null,
+      } as unknown as PlayerRespawnEvent['player'],
+      x: 5,
+      y: 7,
+    };
+
+    await listener?.(event);
+
+    expect(eventBridge.publishPlayerNotification).not.toHaveBeenCalled();
+  });
+});

--- a/apps/dm/src/app/player/player-notification.service.ts
+++ b/apps/dm/src/app/player/player-notification.service.ts
@@ -1,0 +1,81 @@
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
+import { EventBus, type PlayerRespawnEvent } from '@mud/engine';
+import { EventBridgeService } from '../../shared/event-bridge.service';
+
+@Injectable()
+export class PlayerNotificationService
+  implements OnModuleInit, OnModuleDestroy
+{
+  private readonly logger = new Logger(PlayerNotificationService.name);
+  private readonly subscriptions: Array<() => void> = [];
+
+  constructor(private readonly eventBridge: EventBridgeService) {}
+
+  onModuleInit(): void {
+    this.subscriptions.push(
+      EventBus.on('player:respawn', (event) =>
+        this.handlePlayerRespawn(event as PlayerRespawnEvent),
+      ),
+    );
+  }
+
+  onModuleDestroy(): void {
+    for (const unsubscribe of this.subscriptions) {
+      try {
+        unsubscribe();
+      } catch (error) {
+        this.logger.error('Error unsubscribing from event listener', error);
+      }
+    }
+    this.subscriptions.length = 0;
+  }
+
+  private async handlePlayerRespawn(event: PlayerRespawnEvent): Promise<void> {
+    const slackId = event.player.slackId;
+    if (!slackId) {
+      this.logger.warn(
+        `Received player:respawn for player ${event.player.id} without a Slack ID`,
+      );
+      return;
+    }
+
+    const locationText = `(${event.x}, ${event.y})`;
+    const message = `🏥 You have been respawned at ${locationText}. Take a moment to recover before heading back into danger.`;
+
+    await this.eventBridge.publishPlayerNotification(event, [
+      {
+        clientType: 'slack',
+        clientId: `slack:${slackId}`,
+        message,
+        priority: 'high',
+        blocks: [
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: `*You're back on your feet!*\n\nYou awaken at *${locationText}*.`,
+            },
+          },
+          {
+            type: 'context',
+            elements: [
+              {
+                type: 'mrkdwn',
+                text: 'Tip: Check your surroundings and regroup before your next move.',
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    this.logger.debug(
+      `Sent respawn notification to ${slackId} for location ${locationText}`,
+    );
+  }
+}

--- a/apps/dm/src/shared/event-bridge.service.ts
+++ b/apps/dm/src/shared/event-bridge.service.ts
@@ -7,7 +7,10 @@
  */
 
 import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
-import { RedisEventBridge } from '@mud/redis-client';
+import {
+  RedisEventBridge,
+  type NotificationRecipient,
+} from '@mud/redis-client';
 import { EventBus, GameEvent } from '@mud/engine';
 import { env } from '../env';
 
@@ -60,5 +63,16 @@ export class EventBridgeService implements OnModuleInit, OnModuleDestroy {
     }>,
   ): Promise<void> {
     await this.bridge.publishCombatNotifications(event, messages);
+  }
+
+  async publishPlayerNotification(
+    event: GameEvent,
+    recipients: NotificationRecipient[],
+  ): Promise<void> {
+    await this.bridge.publishNotification({
+      type: 'player',
+      recipients,
+      event,
+    });
   }
 }

--- a/apps/slack-bot/jest.config.js
+++ b/apps/slack-bot/jest.config.js
@@ -3,6 +3,7 @@ import baseConfig from '../../jest.base.config.cjs';
 export default {
   ...baseConfig,
   displayName: 'slack-bot',
+  setupFiles: [...(baseConfig.setupFiles ?? []), '<rootDir>/jest.setup.ts'],
   collectCoverageFrom: [
     'src/**/*.ts',
     '!src/**/*.d.ts',

--- a/apps/slack-bot/jest.setup.ts
+++ b/apps/slack-bot/jest.setup.ts
@@ -1,0 +1,5 @@
+process.env.SLACK_BOT_TOKEN =
+  process.env.SLACK_BOT_TOKEN ?? 'test-slack-bot-token';
+process.env.SLACK_SIGNING_SECRET =
+  process.env.SLACK_SIGNING_SECRET ?? 'test-signing-secret';
+process.env.SLACK_APP_TOKEN = process.env.SLACK_APP_TOKEN ?? 'xapp-test-token';


### PR DESCRIPTION
## Summary
- add a player notification service that listens for `player:respawn` events and sends Slack DM notifications via the Redis bridge
- expose a helper on the DM event bridge for publishing player notifications and register the new service with the module
- point DM Jest to built engine/redis artifacts and provide Slack bot Jest setup defaults so tests no longer need real env secrets

## Testing
- yarn workspace @mud/dm test player-notification
- yarn workspace @mud/slack-bot test

------
https://chatgpt.com/codex/tasks/task_e_68e6afd1e1908330a210b71505bc64ac