### PR TITLE
Apply level-ups immediately after combat

### DIFF
--- a/apps/slack-bot/src/handlers/stats/format.ts
+++ b/apps/slack-bot/src/handlers/stats/format.ts
@@ -123,19 +123,19 @@ export function buildPlayerStatsMessage(
 
   if (typeof player.level === 'number' && typeof player.xp === 'number') {
     const xpForNextLevel = player.level * 100;
-    const xpNeeded = Math.max(0, xpForNextLevel - player.xp);
-    blocks.push({
-      type: 'context',
-      elements: [
-        {
-          type: 'mrkdwn',
-          text:
-            xpNeeded > 0
-              ? `🏅 ${xpNeeded} XP needed for level ${player.level + 1}.`
-              : `🏅 You have enough XP to reach the next level!`,
-        },
-      ],
-    });
+    const xpNeeded = xpForNextLevel - player.xp;
+
+    if (xpNeeded > 0) {
+      blocks.push({
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: `🏅 ${xpNeeded} XP needed for level ${player.level + 1}.`,
+          },
+        ],
+      });
+    }
   }
 
   if (options.isSelf) {


### PR DESCRIPTION
## Summary
- track level-up details on combatants so combat messaging can celebrate new levels
- update the DM combat service to persist winner HP, apply level-ups immediately after combat, and append level-up text to rewards
- extend the combat service tests with a level-up scenario and helper mocks for player stat updates

## Testing
- `node ./node_modules/turbo/bin/turbo run test --filter=@mud/dm`

------
https://chatgpt.com/codex/tasks/task_e_68e6cd97cc5083309c86b44b035b75a0