### PR TITLE
Add sniff command to locate nearby monsters

### DIFF
--- a/apps/slack-bot/src/commands.ts
+++ b/apps/slack-bot/src/commands.ts
@@ -7,6 +7,7 @@ export const COMMANDS = {
   LOOK_SHORT: 'l',
   ATTACK: 'attack',
   STATS: 'stats',
+  SNIFF: 'sniff',
   MAP: 'map',
   MOVE: 'move',
   DELETE: 'delete',

--- a/apps/slack-bot/src/handlers/help.ts
+++ b/apps/slack-bot/src/handlers/help.ts
@@ -53,7 +53,7 @@ export const buildHelpBlocks = (): KnownBlock[] => [
       },
       {
         type: 'mrkdwn',
-        text: `*Explore & Fight*\n• \`${COMMANDS.NORTH}\`/\`${COMMANDS.SOUTH}\`/\`${COMMANDS.EAST}\`/\`${COMMANDS.WEST}\`\n• \`${COMMANDS.LOOK}\`\n• \`${COMMANDS.ATTACK}\`\n• \`${COMMANDS.STATS}\``,
+        text: `*Explore & Fight*\n• \`${COMMANDS.NORTH}\`/\`${COMMANDS.SOUTH}\`/\`${COMMANDS.EAST}\`/\`${COMMANDS.WEST}\`\n• \`${COMMANDS.LOOK}\`\n• \`${COMMANDS.ATTACK}\`\n• \`${COMMANDS.SNIFF}\`\n• \`${COMMANDS.STATS}\``,
       },
     ],
   },
@@ -74,8 +74,7 @@ export const buildHelpBlocks = (): KnownBlock[] => [
     type: 'section',
     text: {
       type: 'mrkdwn',
-      text:
-        '*Game Systems*\n• Earn XP from monsters, quests, and discoveries.\n• Combat is turn-based; agility sets turn order and positioning matters.\n• Unlock abilities as you level and spend points in `stats`.',
+      text: '*Game Systems*\n• Earn XP from monsters, quests, and discoveries.\n• Combat is turn-based; agility sets turn order and positioning matters.\n• Unlock abilities as you level and spend points in `stats`.',
     },
   },
   {

--- a/apps/slack-bot/src/handlers/sniff.spec.ts
+++ b/apps/slack-bot/src/handlers/sniff.spec.ts
@@ -1,0 +1,176 @@
+jest.mock('../gql-client', () => {
+  const dmSdk = {
+    GetPlayerWithLocation: jest.fn(),
+    GetLocationEntities: jest.fn(),
+  };
+  return { dmSdk };
+});
+
+import { dmSdk } from '../gql-client';
+import { sniffHandler } from './sniff';
+import { HandlerContext } from './types';
+import { toClientId } from '../utils/clientId';
+
+const mockedDmSdk = dmSdk as unknown as {
+  GetPlayerWithLocation: jest.Mock;
+  GetLocationEntities: jest.Mock;
+};
+
+const makeSay = () =>
+  jest
+    .fn<Promise<void>, [Parameters<HandlerContext['say']>[0]]>()
+    .mockResolvedValue(undefined);
+
+describe('sniffHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reports the nearest monster within the ability-based range', async () => {
+    mockedDmSdk.GetPlayerWithLocation.mockResolvedValue({
+      getPlayer: {
+        success: true,
+        data: {
+          id: '1',
+          slackId: toClientId('U1'),
+          name: 'Hero',
+          x: 0,
+          y: 0,
+          hp: 10,
+          maxHp: 10,
+          strength: 10,
+          agility: 6,
+          health: 10,
+          gold: 0,
+          xp: 0,
+          level: 1,
+          skillPoints: 0,
+          isAlive: true,
+          nearbyMonsters: [],
+        },
+      },
+    });
+
+    mockedDmSdk.GetLocationEntities.mockImplementation(async ({ x, y }) => ({
+      getPlayersAtLocation: [],
+      getMonstersAtLocation:
+        x === 1 && y === 1
+          ? [
+              {
+                __typename: 'Monster',
+                id: 'm1',
+                name: 'Goblin',
+                type: 'Goblin',
+                hp: 8,
+                maxHp: 8,
+                strength: 6,
+                agility: 6,
+                health: 6,
+                x,
+                y,
+                isAlive: true,
+              },
+            ]
+          : [],
+    }));
+
+    const say = makeSay();
+
+    await sniffHandler({
+      userId: 'U1',
+      text: 'sniff',
+      say,
+    } as HandlerContext);
+
+    expect(mockedDmSdk.GetPlayerWithLocation).toHaveBeenCalledWith({
+      slackId: toClientId('U1'),
+    });
+
+    expect(say).toHaveBeenCalledTimes(1);
+    const message = say.mock.calls[0][0] as { text: string };
+    expect(message.text).toContain('Goblin');
+    expect(message.text).toContain('Ability 6');
+    expect(message.text).toContain('range 3');
+    expect(message.text).toContain('2 tiles');
+    expect(message.text).toContain('north-east');
+
+    const entityCalls = mockedDmSdk.GetLocationEntities.mock.calls;
+    expect(entityCalls.length).toBeGreaterThan(0);
+    for (const [variables] of entityCalls) {
+      const { x, y } = variables as { x: number; y: number };
+      const distance = Math.abs(x) + Math.abs(y);
+      expect(distance).toBeLessThanOrEqual(3);
+    }
+  });
+
+  it('informs the player when no monsters are within range', async () => {
+    mockedDmSdk.GetPlayerWithLocation.mockResolvedValue({
+      getPlayer: {
+        success: true,
+        data: {
+          id: '1',
+          slackId: toClientId('U1'),
+          name: 'Hero',
+          x: 0,
+          y: 0,
+          hp: 10,
+          maxHp: 10,
+          strength: 10,
+          agility: 4,
+          health: 10,
+          gold: 0,
+          xp: 0,
+          level: 1,
+          skillPoints: 0,
+          isAlive: true,
+          nearbyMonsters: [],
+        },
+      },
+    });
+
+    mockedDmSdk.GetLocationEntities.mockImplementation(async () => ({
+      getPlayersAtLocation: [],
+      getMonstersAtLocation: [],
+    }));
+
+    const say = makeSay();
+
+    await sniffHandler({
+      userId: 'U1',
+      text: 'sniff',
+      say,
+    } as HandlerContext);
+
+    expect(say).toHaveBeenCalledTimes(1);
+    const message = say.mock.calls[0][0] as { text: string };
+    expect(message.text).toContain('No monsters are within range');
+    expect(message.text).toContain('Ability 4');
+    expect(message.text).toContain('range 2');
+
+    for (const [variables] of mockedDmSdk.GetLocationEntities.mock.calls) {
+      const { x, y } = variables as { x: number; y: number };
+      const distance = Math.abs(x) + Math.abs(y);
+      expect(distance).toBeLessThanOrEqual(2);
+    }
+  });
+
+  it('surfaces the service error when the character is missing', async () => {
+    mockedDmSdk.GetPlayerWithLocation.mockResolvedValue({
+      getPlayer: {
+        success: false,
+        message: 'Player not found',
+      },
+    });
+
+    const say = makeSay();
+
+    await sniffHandler({
+      userId: 'U1',
+      text: 'sniff',
+      say,
+    } as HandlerContext);
+
+    expect(mockedDmSdk.GetLocationEntities).not.toHaveBeenCalled();
+    expect(say).toHaveBeenCalledWith({ text: 'Player not found' });
+  });
+});

--- a/apps/slack-bot/src/handlers/sniff.ts
+++ b/apps/slack-bot/src/handlers/sniff.ts
@@ -1,0 +1,188 @@
+import { dmSdk } from '../gql-client';
+import { HandlerContext } from './types';
+import { registerHandler } from './handlerRegistry';
+import { getUserFriendlyErrorMessage } from './errorUtils';
+import { COMMANDS } from '../commands';
+import { toClientId } from '../utils/clientId';
+
+const CARDINAL_DIRECTIONS = [
+  { dx: 0, dy: 1 }, // north
+  { dx: 1, dy: 0 }, // east
+  { dx: 0, dy: -1 }, // south
+  { dx: -1, dy: 0 }, // west
+];
+
+type QueueEntry = {
+  x: number;
+  y: number;
+  distance: number;
+};
+
+type LocationEntitiesResponse = Awaited<
+  ReturnType<typeof dmSdk.GetLocationEntities>
+>;
+
+type MonstersAtLocation = LocationEntitiesResponse['getMonstersAtLocation'];
+
+const MIN_SNIFF_RANGE = 1;
+
+function sanitizeAbilityScore(value: unknown): number {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.floor(value));
+}
+
+function computeSniffRange(abilityScore: number): number {
+  return Math.max(MIN_SNIFF_RANGE, Math.floor(abilityScore / 2));
+}
+
+function formatAbilitySummary(
+  abilityScore: number,
+  sniffRange: number,
+): string {
+  return `Ability ${abilityScore} → sniff range ${sniffRange} tile${
+    sniffRange === 1 ? '' : 's'
+  }.`;
+}
+
+function formatDirection(dx: number, dy: number): string {
+  if (dx === 0 && dy === 0) {
+    return 'here';
+  }
+
+  const parts: string[] = [];
+  if (dy > 0) {
+    parts.push('north');
+  } else if (dy < 0) {
+    parts.push('south');
+  }
+
+  if (dx > 0) {
+    parts.push('east');
+  } else if (dx < 0) {
+    parts.push('west');
+  }
+
+  return parts.join('-');
+}
+
+export const sniffHandlerHelp = `Sniff out the nearest monster with "${COMMANDS.SNIFF}". The scent range scales with your ability stat.`;
+
+export const sniffHandler = async ({ userId, say }: HandlerContext) => {
+  const missingCharacterMessage = `You don't have a character yet! Use "${COMMANDS.NEW} Name" to create one.`;
+
+  try {
+    const playerRes = await dmSdk.GetPlayerWithLocation({
+      slackId: toClientId(userId),
+    });
+
+    if (!playerRes.getPlayer.success || !playerRes.getPlayer.data) {
+      await say({
+        text: playerRes.getPlayer.message ?? missingCharacterMessage,
+      });
+      return;
+    }
+
+    const player = playerRes.getPlayer.data;
+    const rawAbility = (player as { ability?: number | null }).ability;
+    // Fallback to agility while an explicit ability score is unavailable from the API.
+    const abilityScore = sanitizeAbilityScore(
+      rawAbility !== undefined && rawAbility !== null
+        ? rawAbility
+        : player.agility,
+    );
+    const sniffRange = computeSniffRange(abilityScore);
+    const origin = { x: player.x, y: player.y };
+
+    const queue: QueueEntry[] = [{ x: origin.x, y: origin.y, distance: 0 }];
+    const visited = new Set<string>([`${origin.x},${origin.y}`]);
+
+    let found:
+      | {
+          monsters: MonstersAtLocation;
+          location: QueueEntry;
+        }
+      | undefined;
+
+    while (queue.length) {
+      const current = queue.shift()!;
+      const res = await dmSdk.GetLocationEntities({
+        x: current.x,
+        y: current.y,
+      });
+
+      const monsters = res.getMonstersAtLocation.filter(
+        (monster) => monster.isAlive !== false,
+      );
+
+      if (monsters.length > 0) {
+        found = { monsters, location: current };
+        break;
+      }
+
+      if (current.distance >= sniffRange) {
+        continue;
+      }
+
+      for (const direction of CARDINAL_DIRECTIONS) {
+        const next = {
+          x: current.x + direction.dx,
+          y: current.y + direction.dy,
+          distance: current.distance + 1,
+        };
+        const key = `${next.x},${next.y}`;
+        if (visited.has(key)) {
+          continue;
+        }
+        visited.add(key);
+        queue.push(next);
+      }
+    }
+
+    const abilitySummary = formatAbilitySummary(abilityScore, sniffRange);
+
+    if (!found) {
+      await say({
+        text: `You sniff the air. ${abilitySummary} No monsters are within range.`,
+      });
+      return;
+    }
+
+    const { monsters, location } = found;
+    const dx = location.x - origin.x;
+    const dy = location.y - origin.y;
+    const directionText = formatDirection(dx, dy);
+    const distance = location.distance;
+    const distanceText =
+      distance === 0
+        ? 'right here on your tile'
+        : `${distance} tile${distance === 1 ? '' : 's'} to the ${directionText}`;
+    const coordinateText =
+      distance === 0 ? '' : ` (around ${location.x}, ${location.y})`;
+
+    const [primary, ...others] = monsters;
+    const additionalText =
+      others.length === 0
+        ? ''
+        : others.length === 1
+          ? ' and another monster'
+          : ` and ${others.length} more monsters`;
+    const monsterText = `${primary.name}${additionalText}`;
+
+    const message =
+      distance === 0
+        ? `You sniff the air. ${abilitySummary} The scent of ${monsterText} is ${distanceText}!`
+        : `You sniff the air. ${abilitySummary} You catch the scent of ${monsterText} about ${distanceText}${coordinateText}.`;
+
+    await say({ text: message });
+  } catch (err) {
+    const errorMessage = getUserFriendlyErrorMessage(
+      err,
+      'Failed to sniff for monsters',
+    );
+    await say({ text: errorMessage });
+  }
+};
+
+registerHandler(COMMANDS.SNIFF, sniffHandler);


### PR DESCRIPTION
## Summary
- add the `sniff` command to the command catalogue and help documentation
- implement a BFS-based sniff handler that searches tiles within an ability-scaled radius and reports the nearest monster
- cover the new handler with unit tests for positive, empty, and error scenarios

## Testing
- yarn test sniff

------
https://chatgpt.com/codex/tasks/task_e_68e6e689b494833085e61c962a8938f2