### PR TITLE
Fix sniff resolver client lookup and activity handling

### DIFF
--- a/apps/dm/src/app/graphql/types/response.types.ts
+++ b/apps/dm/src/app/graphql/types/response.types.ts
@@ -73,6 +73,33 @@ export class LocationResponse extends SuccessResponse {
 }
 
 @ObjectType()
+export class SniffData {
+  @Field(() => Int)
+  detectionRadius!: number;
+
+  @Field({ nullable: true })
+  monsterName?: string;
+
+  @Field(() => Float, { nullable: true })
+  distance?: number;
+
+  @Field({ nullable: true })
+  direction?: string;
+
+  @Field(() => Int, { nullable: true })
+  monsterX?: number;
+
+  @Field(() => Int, { nullable: true })
+  monsterY?: number;
+}
+
+@ObjectType()
+export class SniffResponse extends SuccessResponse {
+  @Field(() => SniffData, { nullable: true })
+  data?: SniffData;
+}
+
+@ObjectType()
 export class MonsterResponse extends SuccessResponse {
   @Field(() => Monster, { nullable: true })
   data?: Monster;

--- a/apps/dm/src/app/monster/monster.service.ts
+++ b/apps/dm/src/app/monster/monster.service.ts
@@ -45,6 +45,40 @@ export class MonsterService {
     return MonsterFactory.loadInBounds(minX, maxX, minY, maxY);
   }
 
+  async findNearestMonsterWithinRadius(
+    x: number,
+    y: number,
+    radius: number,
+  ): Promise<{ monster: MonsterEntity; distance: number } | null> {
+    if (!Number.isFinite(radius) || radius <= 0) {
+      return null;
+    }
+
+    const searchRadius = Math.max(1, Math.ceil(radius));
+    const monsters = await this.getMonstersInBounds(
+      x - searchRadius,
+      x + searchRadius,
+      y - searchRadius,
+      y + searchRadius,
+    );
+
+    let closest: { monster: MonsterEntity; distance: number } | null = null;
+
+    for (const monster of monsters) {
+      const dx = monster.position.x - x;
+      const dy = monster.position.y - y;
+      const distance = Math.sqrt(dx * dx + dy * dy);
+      if (distance > radius) {
+        continue;
+      }
+      if (!closest || distance < closest.distance) {
+        closest = { monster, distance };
+      }
+    }
+
+    return closest;
+  }
+
   async moveMonster(monsterId: number): Promise<MonsterEntity> {
     const entity = await MonsterFactory.load(monsterId);
 

--- a/apps/slack-bot/src/commands.ts
+++ b/apps/slack-bot/src/commands.ts
@@ -8,6 +8,7 @@ export const COMMANDS = {
   ATTACK: 'attack',
   STATS: 'stats',
   MAP: 'map',
+  SNIFF: 'sniff',
   MOVE: 'move',
   DELETE: 'delete',
   COMPLETE: 'complete',

--- a/apps/slack-bot/src/generated/dm-graphql.ts
+++ b/apps/slack-bot/src/generated/dm-graphql.ts
@@ -403,6 +403,7 @@ export type Query = {
   getPlayerStats: PlayerStats;
   getPlayersAtLocation: Array<Player>;
   health: HealthCheck;
+  sniffNearestMonster: SniffResponse;
 };
 
 export type QueryGetLookViewArgs = {
@@ -427,6 +428,29 @@ export type QueryGetPlayerStatsArgs = {
 export type QueryGetPlayersAtLocationArgs = {
   x: Scalars['Float']['input'];
   y: Scalars['Float']['input'];
+};
+
+export type QuerySniffNearestMonsterArgs = {
+  clientId?: InputMaybe<Scalars['String']['input']>;
+  slackId?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type SniffData = {
+  __typename?: 'SniffData';
+  detectionRadius: Scalars['Int']['output'];
+  direction?: Maybe<Scalars['String']['output']>;
+  distance?: Maybe<Scalars['Float']['output']>;
+  monsterName?: Maybe<Scalars['String']['output']>;
+  monsterX?: Maybe<Scalars['Int']['output']>;
+  monsterY?: Maybe<Scalars['Int']['output']>;
+};
+
+export type SniffResponse = {
+  __typename?: 'SniffResponse';
+  data?: Maybe<SniffData>;
+  message?: Maybe<Scalars['String']['output']>;
+  result?: Maybe<TickResult>;
+  success: Scalars['Boolean']['output'];
 };
 
 export type SpawnMonsterInput = {
@@ -739,6 +763,28 @@ export type GetLookViewQuery = {
         x: number;
         y: number;
       }> | null;
+    } | null;
+  };
+};
+
+export type SniffNearestMonsterQueryVariables = Exact<{
+  slackId: Scalars['String']['input'];
+}>;
+
+export type SniffNearestMonsterQuery = {
+  __typename?: 'Query';
+  sniffNearestMonster: {
+    __typename?: 'SniffResponse';
+    success: boolean;
+    message?: string | null;
+    data?: {
+      __typename?: 'SniffData';
+      detectionRadius: number;
+      monsterName?: string | null;
+      distance?: number | null;
+      direction?: string | null;
+      monsterX?: number | null;
+      monsterY?: number | null;
     } | null;
   };
 };
@@ -1080,6 +1126,22 @@ export const GetLookViewDocument = gql`
     }
   }
 `;
+export const SniffNearestMonsterDocument = gql`
+  query SniffNearestMonster($slackId: String!) {
+    sniffNearestMonster(slackId: $slackId) {
+      success
+      message
+      data {
+        detectionRadius
+        monsterName
+        distance
+        direction
+        monsterX
+        monsterY
+      }
+    }
+  }
+`;
 export const CreatePlayerDocument = gql`
   mutation CreatePlayer($input: CreatePlayerInput!) {
     createPlayer(input: $input) {
@@ -1299,6 +1361,24 @@ export function getSdk(
             signal,
           }),
         'GetLookView',
+        'query',
+        variables,
+      );
+    },
+    SniffNearestMonster(
+      variables: SniffNearestMonsterQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit['signal'],
+    ): Promise<SniffNearestMonsterQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<SniffNearestMonsterQuery>({
+            document: SniffNearestMonsterDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        'SniffNearestMonster',
         'query',
         variables,
       );

--- a/apps/slack-bot/src/graphql/dm.graphql
+++ b/apps/slack-bot/src/graphql/dm.graphql
@@ -203,6 +203,21 @@ query GetLookView($slackId: String!) {
     }
   }
 }
+
+query SniffNearestMonster($slackId: String!) {
+  sniffNearestMonster(slackId: $slackId) {
+    success
+    message
+    data {
+      detectionRadius
+      monsterName
+      distance
+      direction
+      monsterX
+      monsterY
+    }
+  }
+}
 mutation CreatePlayer($input: CreatePlayerInput!) {
   createPlayer(input: $input) {
     success

--- a/apps/slack-bot/src/handlers/help.ts
+++ b/apps/slack-bot/src/handlers/help.ts
@@ -53,7 +53,7 @@ export const buildHelpBlocks = (): KnownBlock[] => [
       },
       {
         type: 'mrkdwn',
-        text: `*Explore & Fight*\n• \`${COMMANDS.NORTH}\`/\`${COMMANDS.SOUTH}\`/\`${COMMANDS.EAST}\`/\`${COMMANDS.WEST}\`\n• \`${COMMANDS.LOOK}\`\n• \`${COMMANDS.ATTACK}\`\n• \`${COMMANDS.STATS}\``,
+        text: `*Explore & Fight*\n• \`${COMMANDS.NORTH}\`/\`${COMMANDS.SOUTH}\`/\`${COMMANDS.EAST}\`/\`${COMMANDS.WEST}\`\n• \`${COMMANDS.LOOK}\`\n• \`${COMMANDS.SNIFF}\`\n• \`${COMMANDS.ATTACK}\`\n• \`${COMMANDS.STATS}\``,
       },
     ],
   },
@@ -74,8 +74,7 @@ export const buildHelpBlocks = (): KnownBlock[] => [
     type: 'section',
     text: {
       type: 'mrkdwn',
-      text:
-        '*Game Systems*\n• Earn XP from monsters, quests, and discoveries.\n• Combat is turn-based; agility sets turn order and positioning matters.\n• Unlock abilities as you level and spend points in `stats`.',
+      text: '*Game Systems*\n• Earn XP from monsters, quests, and discoveries.\n• Combat is turn-based; agility sets turn order and positioning matters.\n• Unlock abilities as you level and spend points in `stats`.',
     },
   },
   {

--- a/apps/slack-bot/src/handlers/sniff.ts
+++ b/apps/slack-bot/src/handlers/sniff.ts
@@ -1,0 +1,64 @@
+import { dmSdk } from '../gql-client';
+import { HandlerContext } from './types';
+import { registerHandler } from './handlerRegistry';
+import { getUserFriendlyErrorMessage } from './errorUtils';
+import { COMMANDS } from '../commands';
+import { toClientId } from '../utils/clientId';
+
+export const sniffHandlerHelp = `Sniff out the nearest monster within range of your agility. Example: Send "${COMMANDS.SNIFF}".`;
+
+const formatDistance = (distance: number | null | undefined): string => {
+  if (typeof distance !== 'number' || !Number.isFinite(distance)) {
+    return 'some tiles';
+  }
+  const rounded = Math.round(distance * 10) / 10;
+  const trimmed = rounded.toFixed(1).replace(/\.0$/, '');
+  return `${trimmed} tiles`;
+};
+
+export const sniffHandler = async ({ userId, say }: HandlerContext) => {
+  try {
+    const response = await dmSdk.SniffNearestMonster({
+      slackId: toClientId(userId),
+    });
+
+    const payload = response.sniffNearestMonster;
+    if (!payload.success) {
+      await say({
+        text: payload.message ?? 'Failed to sniff for monsters.',
+      });
+      return;
+    }
+
+    const data = payload.data;
+    if (!data || !data.monsterName) {
+      const radius = data?.detectionRadius;
+      const radiusLabel =
+        typeof radius === 'number'
+          ? `${radius} tile${radius === 1 ? '' : 's'}`
+          : 'your range';
+      await say({
+        text:
+          payload.message ??
+          `You sniff the air but can't catch any monster scent within ${radiusLabel}.`,
+      });
+      return;
+    }
+
+    const direction = data.direction ?? 'nearby';
+    const distanceText = formatDistance(data.distance);
+    await say({
+      text:
+        payload.message ??
+        `You catch the scent of ${data.monsterName} about ${distanceText} ${direction}.`,
+    });
+  } catch (err) {
+    const errorMessage = getUserFriendlyErrorMessage(
+      err,
+      'Failed to sniff for monsters',
+    );
+    await say({ text: errorMessage });
+  }
+};
+
+registerHandler(COMMANDS.SNIFF, sniffHandler);

--- a/apps/slack-bot/src/main.ts
+++ b/apps/slack-bot/src/main.ts
@@ -41,6 +41,7 @@ if (receiver?.router) {
 import './handlers/move';
 import './handlers/look';
 import './handlers/attack';
+import './handlers/sniff';
 import './handlers/create';
 import './handlers/reroll';
 import './handlers/complete';
@@ -66,6 +67,7 @@ app.event('app_mention', async ({ event, say }) => {
 **Once you have a character:**
 • Move with "${COMMANDS.NORTH}", "${COMMANDS.SOUTH}", "${COMMANDS.EAST}", "${COMMANDS.WEST}", "${COMMANDS.UP}", "${COMMANDS.DOWN}", "${COMMANDS.LEFT}", "${COMMANDS.RIGHT}"
 • Attack monsters with "${COMMANDS.ATTACK}"
+• Sniff out nearby monsters with "${COMMANDS.SNIFF}"
 • Check stats with "${COMMANDS.STATS}"
 • View map with "${COMMANDS.MAP}"
 
@@ -150,7 +152,8 @@ app.message(async ({ message, say, client }) => {
 • "${COMMANDS.UP}", "${COMMANDS.DOWN}", "${COMMANDS.LEFT}", "${COMMANDS.RIGHT}" - Alternative direction words
 
 ⚔️ **Actions:**
-• "${COMMANDS.ATTACK}" - Attack nearby monsters  
+• "${COMMANDS.ATTACK}" - Attack nearby monsters
+• "${COMMANDS.SNIFF}" - Sniff for nearby monsters
 • "${COMMANDS.STATS}" - View your character stats
 
 📋 **Other:**

--- a/dm-schema.gql
+++ b/dm-schema.gql
@@ -104,6 +104,22 @@ type PlayerResponse {
   data: Player
 }
 
+type SniffData {
+  detectionRadius: Int!
+  monsterName: String
+  distance: Float
+  direction: String
+  monsterX: Int
+  monsterY: Int
+}
+
+type SniffResponse {
+  success: Boolean!
+  message: String
+  result: TickResult
+  data: SniffData
+}
+
 type MonsterResponse {
   success: Boolean!
   message: String
@@ -283,6 +299,7 @@ type Query {
   getPlayersAtLocation(x: Float!, y: Float!): [Player!]!
   getPlayerStats(slackId: String, name: String): PlayerStats!
   getLookView(slackId: String!): LookViewResponse!
+  sniffNearestMonster(slackId: String, clientId: String): SniffResponse!
   health: HealthCheck!
   getGameState: GameStateResponse!
   getMonstersAtLocation(x: Float!, y: Float!): [Monster!]!


### PR DESCRIPTION
## Summary
- ensure the sniff resolver uses `getPlayerByIdentifier` and only updates Slack activity when a Slack ID is provided
- extend the movement resolver spec to cover Slack and client-based sniffing scenarios

## Testing
- `node ./node_modules/turbo/bin/turbo run test --filter=@mud/dm`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68e6f085d2388330904c1b3196bb6679