### PR TITLE
feat(infra): add Slack OAuth secrets/vars and wire to Cloud Run; fix …

### DIFF
--- a/apps/dm/docker-entrypoint.sh
+++ b/apps/dm/docker-entrypoint.sh
@@ -20,4 +20,4 @@ cd /app
 
 # Start the application
 echo "✅ Starting DM service..."
-exec node apps/dm/dist/src/main.js
+exec node apps/dm/dist/main.js

--- a/infra/terraform/cloudrun.tf
+++ b/infra/terraform/cloudrun.tf
@@ -115,6 +115,9 @@ resource "google_cloud_run_v2_service" "services" {
           SLACK_BOT_TOKEN      = google_secret_manager_secret.slack_bot_token.name
           SLACK_SIGNING_SECRET = google_secret_manager_secret.slack_signing_secret.name
           SLACK_APP_TOKEN      = google_secret_manager_secret.slack_app_token.name
+          SLACK_CLIENT_ID      = google_secret_manager_secret.slack_client_id.name
+          SLACK_CLIENT_SECRET  = google_secret_manager_secret.slack_client_secret.name
+          SLACK_STATE_SECRET   = google_secret_manager_secret.slack_state_secret.name
         } : {}
         content {
           name = env.key

--- a/infra/terraform/secrets.tf
+++ b/infra/terraform/secrets.tf
@@ -55,6 +55,30 @@ resource "google_secret_manager_secret" "slack_app_token" {
   depends_on = [google_project_service.apis]
 }
 
+resource "google_secret_manager_secret" "slack_client_id" {
+  secret_id = "slack-client-id"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_secret_manager_secret" "slack_client_secret" {
+  secret_id = "slack-client-secret"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_secret_manager_secret" "slack_state_secret" {
+  secret_id = "slack-state-secret"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.apis]
+}
+
 resource "google_secret_manager_secret_version" "slack_bot_token" {
   count       = var.slack_bot_token == null ? 0 : 1
   secret      = google_secret_manager_secret.slack_bot_token.id
@@ -71,6 +95,24 @@ resource "google_secret_manager_secret_version" "slack_app_token" {
   count       = var.slack_app_token == null ? 0 : 1
   secret      = google_secret_manager_secret.slack_app_token.id
   secret_data = var.slack_app_token
+}
+
+resource "google_secret_manager_secret_version" "slack_client_id" {
+  count       = var.slack_client_id == null ? 0 : 1
+  secret      = google_secret_manager_secret.slack_client_id.id
+  secret_data = var.slack_client_id
+}
+
+resource "google_secret_manager_secret_version" "slack_client_secret" {
+  count       = var.slack_client_secret == null ? 0 : 1
+  secret      = google_secret_manager_secret.slack_client_secret.id
+  secret_data = var.slack_client_secret
+}
+
+resource "google_secret_manager_secret_version" "slack_state_secret" {
+  count       = var.slack_state_secret == null ? 0 : 1
+  secret      = google_secret_manager_secret.slack_state_secret.id
+  secret_data = var.slack_state_secret
 }
 
 resource "google_secret_manager_secret_iam_binding" "slack_bot_token_accessor" {
@@ -91,6 +133,30 @@ resource "google_secret_manager_secret_iam_binding" "slack_signing_secret_access
 
 resource "google_secret_manager_secret_iam_binding" "slack_app_token_accessor" {
   secret_id = google_secret_manager_secret.slack_app_token.id
+  role      = "roles/secretmanager.secretAccessor"
+  members = [
+    "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com"
+  ]
+}
+
+resource "google_secret_manager_secret_iam_binding" "slack_client_id_accessor" {
+  secret_id = google_secret_manager_secret.slack_client_id.id
+  role      = "roles/secretmanager.secretAccessor"
+  members = [
+    "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com"
+  ]
+}
+
+resource "google_secret_manager_secret_iam_binding" "slack_client_secret_accessor" {
+  secret_id = google_secret_manager_secret.slack_client_secret.id
+  role      = "roles/secretmanager.secretAccessor"
+  members = [
+    "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com"
+  ]
+}
+
+resource "google_secret_manager_secret_iam_binding" "slack_state_secret_accessor" {
+  secret_id = google_secret_manager_secret.slack_state_secret.id
   role      = "roles/secretmanager.secretAccessor"
   members = [
     "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com"

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -65,3 +65,7 @@ services = {
     }
   }
 }
+
+slack_client_id     = null
+slack_client_secret = null
+slack_state_secret  = null

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -142,6 +142,27 @@ variable "slack_app_token" {
   sensitive   = true
 }
 
+variable "slack_client_id" {
+  description = "Slack OAuth Client ID"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "slack_client_secret" {
+  description = "Slack OAuth Client Secret"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "slack_state_secret" {
+  description = "Slack OAuth state secret"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
 variable "github_repository" {
   description = "GitHub repository (OWNER/REPO) that is allowed to access Workload Identity Federation. Leave null to skip creation."
   type        = string


### PR DESCRIPTION
…DM entrypoint

- add Secret Manager resources, versions, and IAM bindings for Slack OAuth: slack_client_id, slack_client_secret, slack_state_secret
- add corresponding terraform variables (sensitive) and example TFVARS entries
- expose SLACK_CLIENT_ID, SLACK_CLIENT_SECRET, SLACK_STATE_SECRET to slack-bot Cloud Run env
- small fix to DM docker-entrypoint to use compiled dist/main.js