### PR TITLE
ci(deploy): simplify Deploy workflow, add local deploy scripts, CI jo…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,184 +2,45 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - main
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
-  # Determine which apps are affected by changes
-  detect-changes:
-    name: Detect affected packages
-    runs-on: ubuntu-latest
-    outputs:
-      affected-packages: ${{ steps.affected.outputs.packages }}
-      has-affected-packages: ${{ steps.affected.outputs.has-packages }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Fetch base branch
-        run: |
-          git fetch origin main:main
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'yarn'
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Get affected packages
-        id: affected
-        run: |
-          # Get affected projects using turbo (compare against main)
-          RAW_OUTPUT=$(yarn --silent turbo run build --dry=json --filter='[main]' || true)
-          AFFECTED_OUTPUT=$(python3 -c 'import json, sys; data = sys.stdin.read(); start = data.find("{"); end = data.rfind("}"); print(json.dumps({"tasks": []}) if start == -1 or end == -1 or end < start else data[start:end+1])' <<< "$RAW_OUTPUT")
-
-          if [ -z "$AFFECTED_OUTPUT" ]; then
-            AFFECTED_OUTPUT='{"tasks":[]}'
-          fi
-
-          # Extract all package names from affected tasks (including libs)
-          PACKAGES=$(echo "$AFFECTED_OUTPUT" | jq -c '[.tasks[] | select(.package | startswith("@mud/")) | .package | sub("@mud/"; "")] | unique')
-
-          echo "Affected packages: $PACKAGES"
-          echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
-
-          # Check if we have any affected packages
-          HAS_PACKAGES=$(echo "$PACKAGES" | jq 'length > 0')
-          echo "has-packages=$HAS_PACKAGES" >> $GITHUB_OUTPUT
-
-  # Run tests for affected packages
-  test:
-    name: Test ${{ matrix.package }}
-    runs-on: ubuntu-latest
-    needs: detect-changes
-    if: needs.detect-changes.outputs.has-affected-packages == 'true'
-    strategy:
-      matrix:
-        package: ${{ fromJson(needs.detect-changes.outputs.affected-packages) }}
-      fail-fast: false
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'yarn'
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Run tests
-        run: yarn turbo run test --filter=@mud/${{ matrix.package }}
-
-  # Build affected packages to validate they compile
-  build:
-    name: Build ${{ matrix.package }}
-    runs-on: ubuntu-latest
-    needs: detect-changes
-    if: needs.detect-changes.outputs.has-affected-packages == 'true'
-    strategy:
-      matrix:
-        package: ${{ fromJson(needs.detect-changes.outputs.affected-packages) }}
-      fail-fast: false
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'yarn'
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Build package
-        run: yarn turbo run build --filter=@mud/${{ matrix.package }}
-
-  # Run linting
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: 20
           cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - run: yarn turbo lint
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Run lint
-        run: yarn lint
-
-  # Summary job to report CI status
-  ci-summary:
-    name: CI Summary
+  test:
+    name: Unit tests
     runs-on: ubuntu-latest
-    needs: [detect-changes, test, build, lint]
-    if: always()
     steps:
-      - name: Report Summary
-        run: |
-          echo "## CI Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - run: yarn turbo run test
 
-          echo "### 🧪 Tests" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ needs.detect-changes.outputs.has-affected-packages }}" == "true" ]; then
-            if [ "${{ needs.test.result }}" == "success" ]; then
-              echo "✅ All tests passed" >> $GITHUB_STEP_SUMMARY
-            elif [ "${{ needs.test.result }}" == "skipped" ]; then
-              echo "⏭️ Tests skipped" >> $GITHUB_STEP_SUMMARY
-            else
-              echo "❌ Some tests failed" >> $GITHUB_STEP_SUMMARY
-            fi
-          else
-            echo "ℹ️ No packages affected" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          echo "### 🔨 Build" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ needs.detect-changes.outputs.has-affected-packages }}" == "true" ]; then
-            if [ "${{ needs.build.result }}" == "success" ]; then
-              echo "✅ All builds succeeded" >> $GITHUB_STEP_SUMMARY
-            elif [ "${{ needs.build.result }}" == "skipped" ]; then
-              echo "⏭️ Builds skipped" >> $GITHUB_STEP_SUMMARY
-            else
-              echo "❌ Some builds failed" >> $GITHUB_STEP_SUMMARY
-            fi
-          else
-            echo "ℹ️ No packages affected" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          echo "### 🔍 Lint" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ needs.lint.result }}" == "success" ]; then
-            echo "✅ Linting passed" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "❌ Linting failed" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          echo "Affected packages: ${{ needs.detect-changes.outputs.affected-packages }}" >> $GITHUB_STEP_SUMMARY
-
-      - name: Check if CI passed
-        if: |
-          needs.lint.result != 'success' ||
-          (needs.detect-changes.outputs.has-affected-packages == 'true' && 
-           (needs.test.result != 'success' || needs.build.result != 'success'))
-        run: |
-          echo "CI checks failed"
-          exit 1
+  build:
+    name: Build (sanity)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - run: yarn turbo run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,166 +1,83 @@
-name: Deploy to GCP
+name: Deploy
 
 on:
   push:
-    branches:
-      - main
-  workflow_dispatch:
-    inputs:
-      apps:
-        description: 'Apps to deploy (comma-separated: dm,slack-bot,tick,world or "all")'
-        required: false
-        default: 'all'
-        type: string
-      deploy_infrastructure:
-        description: 'Deploy infrastructure changes (Terraform)'
-        required: false
-        default: false
-        type: boolean
-
-env:
-  GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-  GCP_REGION: ${{ secrets.GCP_REGION }}
-  REGISTRY: ${{ secrets.GCP_REGION }}-docker.pkg.dev
-  ARTIFACT_REPO: mud-registry
+    branches: [main]
+  workflow_dispatch: {}
 
 permissions:
   contents: read
   id-token: write
 
+env:
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  REGION: ${{ secrets.GCP_REGION }}
+  ARTIFACT_REPO: mud-registry
+
 jobs:
-  # Determine which apps are affected by changes
-  detect-changes:
-    name: Detect affected applications
+  deploy:
     runs-on: ubuntu-latest
-    outputs:
-      affected-apps: ${{ steps.affected.outputs.apps }}
-      affected-packages: ${{ steps.affected.outputs.packages }}
-      has-affected-apps: ${{ steps.affected.outputs.has-apps }}
-      has-affected-packages: ${{ steps.affected.outputs.has-packages }}
-      infra-changed: ${{ steps.check-infra.outputs.changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
-      - name: Setup Node.js
+      - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: 20
           cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Get affected applications
-        id: affected
-        run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            ./scripts/ci/detect-affected-apps.sh manual "${{ inputs.apps }}" "$GITHUB_OUTPUT"
-          else
-            ./scripts/ci/detect-affected-apps.sh auto "" "$GITHUB_OUTPUT"
-          fi
-
-      - name: Check infrastructure changes
-        id: check-infra
-        run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            ./scripts/ci/check-infra-changes.sh manual "${{ inputs.deploy_infrastructure }}" "" "" "$GITHUB_OUTPUT"
-          else
-            ./scripts/ci/check-infra-changes.sh auto "" "${{ github.event.before }}" "${{ github.sha }}" "$GITHUB_OUTPUT"
-          fi
-
-  # Terraform apply handled manually; no CI apply
-
-  # Build and push Docker images for affected apps
-  build-and-push:
-    name: Build and push ${{ matrix.app }}
-    runs-on: ubuntu-latest
-    needs: [detect-changes]
-    environment: Production
-    if: needs.detect-changes.outputs.has-affected-apps == 'true'
-    strategy:
-      matrix:
-        app: ${{ fromJson(needs.detect-changes.outputs.affected-apps) }}
-      fail-fast: false
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Authenticate to Google Cloud
+      - name: Authenticate to Google Cloud (WIF)
         uses: google-github-actions/auth@v2
         with:
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_DEPLOY_SA }}
 
-      - name: Set up Cloud SDK
+      - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v2
-
-      - name: Configure Docker for Artifact Registry
-        run: gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev
-
-      - name: Build and push Docker image
-        run: ./scripts/ci/build-and-push-docker.sh "${{ matrix.app }}" "${{ env.REGISTRY }}" "${{ env.GCP_PROJECT_ID }}" "${{ env.ARTIFACT_REPO }}" "${{ github.sha }}"
-
-      - name: Deploy to Cloud Run
-        run: ./scripts/ci/deploy-to-cloudrun.sh "${{ matrix.app }}" "${{ env.REGISTRY }}" "${{ env.GCP_PROJECT_ID }}" "${{ env.ARTIFACT_REPO }}" "${{ github.sha }}" "${{ env.GCP_REGION }}"
-
-  sync-env-vars:
-    name: Sync Cloud Run environment
-    runs-on: ubuntu-latest
-    needs: [detect-changes, build-and-push]
-    if: |
-      needs.detect-changes.outputs.has-affected-apps == 'true' &&
-      needs.build-and-push.result == 'success'
-    environment: Production
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
         with:
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          project_id: ${{ env.PROJECT_ID }}
 
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+      - name: Configure Docker auth for Artifact Registry
+        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
 
-      - name: Sync Cloud Run env vars
-        run: ./scripts/ci/sync-cloudrun-env-vars.sh "${{ env.GCP_PROJECT_ID }}" "${{ env.GCP_REGION }}"
+      - name: Compute image tag
+        id: tag
+        run: echo "tag=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
 
-  # Summary job to report deployment status
-  deploy-summary:
-    name: Deployment Summary
-    runs-on: ubuntu-latest
-    needs: [detect-changes, build-and-push, sync-env-vars]
-    if: always()
-    steps:
-      - name: Report Summary
+      - name: Build images
         run: |
-          echo "## Deployment Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          set -euo pipefail
+          export TAG=${{ steps.tag.outputs.tag }}
+          docker build -t $REGION-docker.pkg.dev/$PROJECT_ID/$ARTIFACT_REPO/dm:$TAG apps/dm
+          docker build -t $REGION-docker.pkg.dev/$PROJECT_ID/$ARTIFACT_REPO/world:$TAG apps/world
+          docker build -t $REGION-docker.pkg.dev/$PROJECT_ID/$ARTIFACT_REPO/slack-bot:$TAG apps/slack-bot
+          docker build -t $REGION-docker.pkg.dev/$PROJECT_ID/$ARTIFACT_REPO/tick:$TAG apps/tick
 
-          if [ "${{ needs.detect-changes.outputs.infra-changed }}" == "true" ]; then
-            echo "### 🏗️ Infrastructure" >> $GITHUB_STEP_SUMMARY
-            echo "ℹ️ Infrastructure changes detected. Terraform deploy is handled manually outside CI." >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-          fi
-
-          echo "### 🚀 Applications" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ needs.detect-changes.outputs.has-affected-apps }}" == "true" ]; then
-            echo "Affected apps: ${{ needs.detect-changes.outputs.affected-apps }}" >> $GITHUB_STEP_SUMMARY
-            if [ "${{ needs.build-and-push.result }}" == "success" ]; then
-              echo "✅ All applications deployed successfully" >> $GITHUB_STEP_SUMMARY
-            else
-              echo "❌ Some applications failed to deploy" >> $GITHUB_STEP_SUMMARY
-            fi
-            if [ "${{ needs.sync-env-vars.result }}" == "success" ]; then
-              echo "🔄 Cloud Run environment variables synced" >> $GITHUB_STEP_SUMMARY
-            elif [ "${{ needs.sync-env-vars.result }}" == "failure" ]; then
-              echo "⚠️ Cloud Run environment sync failed" >> $GITHUB_STEP_SUMMARY
-            fi
-          else
-            echo "ℹ️ No applications affected by this push" >> $GITHUB_STEP_SUMMARY
-          fi
+      - name: Push images
+        run: |
+          set -euo pipefail
+          export TAG=${{ steps.tag.outputs.tag }}
+          docker push $REGION-docker.pkg.dev/$PROJECT_ID/$ARTIFACT_REPO/dm:$TAG
+          docker push $REGION-docker.pkg.dev/$PROJECT_ID/$ARTIFACT_REPO/world:$TAG
+          docker push $REGION-docker.pkg.dev/$PROJECT_ID/$ARTIFACT_REPO/slack-bot:$TAG
+          docker push $REGION-docker.pkg.dev/$PROJECT_ID/$ARTIFACT_REPO/tick:$TAG
+      - name: Update Cloud Run services (image only)
+        run: |
+          set -euo pipefail
+          export TAG=${{ steps.tag.outputs.tag }}
+          gcloud run services update mud-dm \
+            --image $REGION-docker.pkg.dev/$PROJECT_ID/$ARTIFACT_REPO/dm:$TAG \
+            --region $REGION --platform managed --quiet
+          gcloud run services update mud-world \
+            --image $REGION-docker.pkg.dev/$PROJECT_ID/$ARTIFACT_REPO/world:$TAG \
+            --region $REGION --platform managed --quiet
+          gcloud run services update mud-slack-bot \
+            --image $REGION-docker.pkg.dev/$PROJECT_ID/$ARTIFACT_REPO/slack-bot:$TAG \
+            --region $REGION --platform managed --quiet
+          gcloud run services update mud-tick \
+            --image $REGION-docker.pkg.dev/$PROJECT_ID/$ARTIFACT_REPO/tick:$TAG \
+            --region $REGION --platform managed --quiet

--- a/apps/slack-bot/src/handlers/sniff.ts
+++ b/apps/slack-bot/src/handlers/sniff.ts
@@ -36,13 +36,13 @@ const resolveDistanceLabel = (
 const arrowForDirection = (direction?: string): string => {
   switch ((direction || '').toLowerCase()) {
     case 'north':
-      return ':arrow_up_small:';
+      return ':arrow_up:';
     case 'south':
-      return ':arrow_down_small:';
+      return ':arrow_down:';
     case 'east':
-      return ':arrow_right_small:';
+      return ':arrow_right:';
     case 'west':
-      return ':arrow_left_small:';
+      return ':arrow_left:';
     case 'here':
       return ':round_pushpin:';
     default:

--- a/scripts/ci/local-build-push-and-apply.sh
+++ b/scripts/ci/local-build-push-and-apply.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build and push images, then terraform apply to update Cloud Run to this tag.
+# Usage: ./scripts/ci/local-build-push-and-apply.sh [project_id] [region] [tag]
+# - If project/region omitted, falls back to gcloud config.
+# - If tag omitted, uses short git SHA.
+
+PROJECT_ID=${1:-}
+REGION=${2:-}
+TAG=${3:-}
+ARTIFACT_REPO=${ARTIFACT_REPO:-mud-registry}
+
+if [[ -z "$PROJECT_ID" ]]; then
+  PROJECT_ID=$(gcloud config get-value project 2>/dev/null || true)
+fi
+
+if [[ -z "$REGION" ]]; then
+  REGION=$(gcloud config get-value run/region 2>/dev/null || true)
+  if [[ -z "$REGION" ]]; then
+    REGION=$(gcloud config get-value compute/region 2>/dev/null || true)
+  fi
+fi
+
+if [[ -z "$PROJECT_ID" || -z "$REGION" ]]; then
+  echo "Usage: $0 [project_id] [region] [tag]" >&2
+  echo "Hint: set defaults via 'gcloud config set project <id>' and 'gcloud config set run/region <region>'" >&2
+  exit 1
+fi
+
+if [[ -z "$TAG" ]]; then
+  TAG=$(git rev-parse --short=12 HEAD)
+fi
+
+echo "Project: $PROJECT_ID"
+echo "Region:  $REGION"
+echo "Tag:     $TAG"
+
+echo "Configuring docker auth..."
+gcloud auth configure-docker "$REGION-docker.pkg.dev" --quiet
+
+set -x
+
+docker build -t "$REGION-docker.pkg.dev/$PROJECT_ID/$ARTIFACT_REPO/dm:$TAG" -f apps/dm/Dockerfile .
+
+docker build -t "$REGION-docker.pkg.dev/$PROJECT_ID/$ARTIFACT_REPO/world:$TAG" -f apps/world/Dockerfile .
+
+docker build -t "$REGION-docker.pkg.dev/$PROJECT_ID/$ARTIFACT_REPO/slack-bot:$TAG" -f apps/slack-bot/Dockerfile .
+
+docker build -t "$REGION-docker.pkg.dev/$PROJECT_ID/$ARTIFACT_REPO/tick:$TAG" -f apps/tick/Dockerfile .
+set +x
+
+echo "Pushing images..."
+set -x
+
+docker push "$REGION-docker.pkg.dev/$PROJECT_ID/$ARTIFACT_REPO/dm:$TAG"
+docker push "$REGION-docker.pkg.dev/$PROJECT_ID/$ARTIFACT_REPO/world:$TAG"
+docker push "$REGION-docker.pkg.dev/$PROJECT_ID/$ARTIFACT_REPO/slack-bot:$TAG"
+docker push "$REGION-docker.pkg.dev/$PROJECT_ID/$ARTIFACT_REPO/tick:$TAG"
+set +x
+
+echo "Running terraform apply..."
+"$(dirname "$0")/local-tf-apply.sh" "$PROJECT_ID" "$REGION" "$TAG"

--- a/scripts/ci/local-tf-apply.sh
+++ b/scripts/ci/local-tf-apply.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./scripts/ci/local-tf-apply.sh [project_id] [region] [image_tag]
+# - If project/region are omitted, falls back to gcloud config.
+# - If image_tag is omitted, uses the short git SHA.
+
+PROJECT_ID=${1:-}
+REGION=${2:-}
+TAG=${3:-}
+
+if [[ -z "$PROJECT_ID" ]]; then
+  PROJECT_ID=$(gcloud config get-value project 2>/dev/null || true)
+fi
+
+if [[ -z "$REGION" ]]; then
+  REGION=$(gcloud config get-value run/region 2>/dev/null || true)
+  if [[ -z "$REGION" ]]; then
+    REGION=$(gcloud config get-value compute/region 2>/dev/null || true)
+  fi
+fi
+
+if [[ -z "$PROJECT_ID" || -z "$REGION" ]]; then
+  echo "Usage: $0 [project_id] [region] [image_tag]" >&2
+  echo "Hint: set defaults via 'gcloud config set project <id>' and 'gcloud config set run/region <region>'" >&2
+  exit 1
+fi
+
+if [[ -z "$TAG" ]]; then
+  TAG=$(git rev-parse --short=12 HEAD)
+fi
+
+echo "Project: $PROJECT_ID"
+echo "Region:  $REGION"
+echo "Image tag: $TAG"
+
+pushd "$(dirname "$0")/../../infra/terraform" >/dev/null
+terraform init -input=false
+TF_VAR_project_id="$PROJECT_ID" \
+TF_VAR_region="$REGION" \
+TF_VAR_image_version="$TAG" \
+TF_VAR_git_commit_sha="$TAG" \
+terraform apply -auto-approve -input=false
+popd >/dev/null


### PR DESCRIPTION
…b, docs, and tweak sniff arrows

- Add a lightweight test-and-lint job to .github/workflows/ci.yml to run linting and tests on PRs and pushes.
- Simplify .github/workflows/deploy.yml: remove affected-app detection and matrix builds; always build/push all images and update Cloud Run services (no Terraform in CI). Use Workload Identity Federation and deploy service account for auth.
- Add local deployment helpers:
  - scripts/ci/local-build-push-and-apply.sh — build & push images then run local Terraform apply helper
  - scripts/ci/local-tf-apply.sh — wrapper to run terraform apply with image tag and TF_VARs
- Update README with CI/CD instructions, required GCP secrets, and guidance that Terraform is the source of truth for Cloud Run env vars.
- UX: swap small arrow emojis to standard arrows in the Slack sniff handler for clearer Block Kit rendering.