### PR TITLE
deploy: export REGION in world build step and add Terraform setup ear…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Build and push world image
         run: |
-          set -euo pipefailexport REGION
+          set -euo pipefail
           REPO="${REGION}-docker.pkg.dev/${PROJECT_ID}/${ARTIFACT_REPO}"
           docker build -f apps/world/Dockerfile -t "$REPO/world:${IMAGE_TAG}" .
           docker push "$REPO/world:${IMAGE_TAG}"


### PR DESCRIPTION
…lier

Export REGION in the world image build script so the REPO variable is formed correctly. Add hashicorp/setup-terraform@v3 before writing backend config so Terraform is available for init/apply steps.