### PR TITLE
slack-bot, infra(terraform): enable bot token; robust Slack ID parsin…

### DIFF
--- a/apps/slack-bot/src/main.ts
+++ b/apps/slack-bot/src/main.ts
@@ -12,7 +12,7 @@ const installationStore = new PrismaInstallationStore({
   prismaTable: getPrismaClient().slackAppInstallation,
 });
 const app = new App({
-  // token: env.SLACK_BOT_TOKEN,
+  token: env.SLACK_BOT_TOKEN,
   signingSecret: env.SLACK_SIGNING_SECRET,
   socketMode: false,
   // OAuth (optional): if clientId/clientSecret/stateSecret are provided, installer is enabled

--- a/apps/slack-bot/src/notification.service.ts
+++ b/apps/slack-bot/src/notification.service.ts
@@ -59,8 +59,7 @@ export class NotificationService {
     // Send message to each recipient
     for (const recipient of notification.recipients) {
       try {
-        // Extract Slack user ID from clientId format "slack:U123456"
-        const slackUserId = recipient.clientId.split(':')[1];
+        const slackUserId = this.extractSlackUserId(recipient.clientId);
 
         if (!slackUserId) {
           console.error(`Invalid clientId format: ${recipient.clientId}`);
@@ -119,5 +118,21 @@ export class NotificationService {
         );
       }
     }
+  }
+
+  private extractSlackUserId(
+    clientId: string | null | undefined,
+  ): string | null {
+    if (!clientId) return null;
+    const trimmed = clientId.trim();
+    if (!trimmed) return null;
+
+    if (trimmed.includes(':')) {
+      const [, id] = trimmed.split(':', 2);
+      return id && id.trim().length > 0 ? id.trim() : null;
+    }
+
+    // Accept raw Slack IDs (e.g., U123456) for backward compatibility
+    return trimmed;
   }
 }

--- a/infra/terraform/cloudrun.tf
+++ b/infra/terraform/cloudrun.tf
@@ -12,7 +12,7 @@ resource "google_cloud_run_service" "world" {
     metadata {
       annotations = {
         "run.googleapis.com/vpc-access-connector" = google_vpc_access_connector.serverless.id
-        "run.googleapis.com/vpc-access-egress"    = "all-traffic"
+        "run.googleapis.com/vpc-access-egress"    = "private-ranges-only"
         "run.googleapis.com/cloudsql-instances"   = google_sql_database_instance.postgres.connection_name
       }
       labels = {
@@ -90,7 +90,7 @@ resource "google_cloud_run_service" "dm" {
     metadata {
       annotations = {
         "run.googleapis.com/vpc-access-connector" = google_vpc_access_connector.serverless.id
-        "run.googleapis.com/vpc-access-egress"    = "all-traffic"
+        "run.googleapis.com/vpc-access-egress"    = "private-ranges-only"
         "run.googleapis.com/cloudsql-instances"   = google_sql_database_instance.postgres.connection_name
       }
       labels = {
@@ -204,7 +204,7 @@ resource "google_cloud_run_service" "slack_bot" {
     metadata {
       annotations = {
         "run.googleapis.com/vpc-access-connector" = google_vpc_access_connector.serverless.id
-        "run.googleapis.com/vpc-access-egress"    = "all-traffic"
+        "run.googleapis.com/vpc-access-egress"    = "private-ranges-only"
         "run.googleapis.com/cloudsql-instances"   = google_sql_database_instance.postgres.connection_name
       }
       labels = {

--- a/infra/terraform/secrets.tf
+++ b/infra/terraform/secrets.tf
@@ -1,22 +1,22 @@
 locals {
   provided_secret_ids = {
-    openai              = "openai-api-key"
-    slack_bot_token     = "slack-bot-token"
+    openai               = "openai-api-key"
+    slack_bot_token      = "slack-bot-token"
     slack_signing_secret = "slack-signing-secret"
-    slack_app_token     = "slack-app-token"
-    slack_client_id     = "slack-client-id"
-    slack_client_secret = "slack-client-secret"
-    slack_state_secret  = "slack-state-secret"
+    slack_app_token      = "slack-app-token"
+    slack_client_id      = "slack-client-id"
+    slack_client_secret  = "slack-client-secret"
+    slack_state_secret   = "slack-state-secret"
   }
 
   provided_secret_values = {
-    openai              = var.openai_api_key
-    slack_bot_token     = var.slack_bot_token
+    openai               = var.openai_api_key
+    slack_bot_token      = var.slack_bot_token
     slack_signing_secret = var.slack_signing_secret
-    slack_app_token     = var.slack_app_token
-    slack_client_id     = var.slack_client_id
-    slack_client_secret = var.slack_client_secret
-    slack_state_secret  = var.slack_state_secret
+    slack_app_token      = var.slack_app_token
+    slack_client_id      = var.slack_client_id
+    slack_client_secret  = var.slack_client_secret
+    slack_state_secret   = var.slack_state_secret
   }
 
   provided_secrets_with_values = nonsensitive({
@@ -26,7 +26,7 @@ locals {
   })
 
   db_password_urlencoded = urlencode(random_password.db_password.result)
-  database_url           = "postgresql://${var.database_user}:${local.db_password_urlencoded}@/${var.database_name}?host=/cloudsql/${google_sql_database_instance.postgres.connection_name}"
+  database_url           = "postgresql://${var.database_user}:${local.db_password_urlencoded}@localhost/${var.database_name}?host=/cloudsql/${google_sql_database_instance.postgres.connection_name}&schema=public"
 }
 
 resource "google_secret_manager_secret" "provided" {


### PR DESCRIPTION
…g; tighten egress; fix DB secret URL

- main.ts: re-enable SLACK_BOT_TOKEN in App config so the bot can authenticate
- notification.service.ts: replace fragile recipient.clientId.split(':')[1] with extractSlackUserId helper to accept "slack:U123" or raw IDs and handle missing/empty values safely
- cloudrun.tf: set run.googleapis.com/vpc-access-egress -> "private-ranges-only" (was "all-traffic") for world, dm, and slack_bot services to restrict egress
- secrets.tf: minor formatting alignment and update database_url to use localhost and include "&schema=public" for correct Cloud SQL socket usage