### PR TITLE
test(dm): ensure leveling is uncapped

### DIFF
--- a/apps/dm/src/app/player/player.service.spec.ts
+++ b/apps/dm/src/app/player/player.service.spec.ts
@@ -167,4 +167,17 @@ describe('PlayerService', () => {
       expect.objectContaining({ eventType: 'player:death' }),
     );
   });
+
+  it('levels beyond 20 when provided enough XP', async () => {
+    const player = makePlayer({ level: 1, xp: 0 });
+    mockFindPlayerBySlackUser.mockResolvedValueOnce(player);
+    mockPrisma.player.update.mockResolvedValue(undefined);
+    mockPrisma.player.findUnique.mockResolvedValue(player);
+
+    const result = await service.updatePlayerStats('T1', 'U1', {
+      xp: 100_000,
+    });
+
+    expect(result.level).toBeGreaterThan(20);
+  });
 });


### PR DESCRIPTION
### Motivation
- Prevent regressions that would impose a maximum player level by adding a test that verifies players can advance past level 20 when given large XP.

### Description
- Added a unit test in `apps/dm/src/app/player/player.service.spec.ts` that invokes `updatePlayerStats` with `xp: 100_000` and asserts the returned player's `level` is greater than 20.

### Testing
- No automated test suite was executed for this change; only the spec file `apps/dm/src/app/player/player.service.spec.ts` was added/updated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69693552648c83308d7c106143c94b22)