### PR TITLE
[codex] fix web slack oauth start navigation

### DIFF
--- a/apps/web/src/app/me/page.tsx
+++ b/apps/web/src/app/me/page.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { getXpToNextLevel } from '@mud/constants';
 import { getPrismaClient, ItemType, PlayerSlot } from '@mud/database';
 import { buildInventoryModel } from '@mud/inventory';
@@ -95,9 +94,9 @@ export default async function CharacterPage() {
           <p>You are not signed in.</p>
         </section>
         <div>
-          <Link className="slack-auth-link" href="/api/auth/slack/start">
+          <a className="slack-auth-link" href="/api/auth/slack/start">
             Sign in with Slack
-          </Link>
+          </a>
         </div>
       </main>
     );

--- a/apps/web/src/app/me/store/page.tsx
+++ b/apps/web/src/app/me/store/page.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { getPrismaClient } from '@mud/database';
 import {
   buildInventoryModel,
@@ -102,9 +101,9 @@ export default async function StorePage() {
           <p>You are not signed in.</p>
         </section>
         <div>
-          <Link className="slack-auth-link" href="/api/auth/slack/start">
+          <a className="slack-auth-link" href="/api/auth/slack/start">
             Sign in with Slack
-          </Link>
+          </a>
         </div>
       </main>
     );

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { getSession } from './lib/slack-auth';
 
 export default async function Home() {
@@ -74,9 +73,9 @@ export default async function Home() {
           <span>Add to Slack</span>
         </a>
         {session ? null : (
-          <Link className="slack-auth-link" href="/api/auth/slack/start">
+          <a className="slack-auth-link" href="/api/auth/slack/start">
             Sign in with Slack
-          </Link>
+          </a>
         )}
       </div>
     </main>


### PR DESCRIPTION
## Summary
This PR fixes Slack web sign-in flow failures caused by client-side route fetch behavior when initiating OAuth.

## What Users Saw
Clicking **Sign in with Slack** could fail in-browser with a CORS error similar to:

- request to `/api/auth/slack/start?_rsc=...`
- redirect to `https://slack.com/oauth/v2/authorize...`
- blocked by CORS policy during a preflight/fetch flow

## Root Cause
The sign-in CTAs used Next.js `Link` to an API route (`/api/auth/slack/start`). In App Router contexts, that can be handled as an RSC/data fetch rather than a full document navigation. OAuth initiation must be a top-level browser navigation so redirects to Slack are not constrained by fetch CORS semantics.

## Fix
Replaced `Link` with a plain anchor (`<a href="/api/auth/slack/start">`) for all Slack sign-in entry points so the browser performs a normal full-page redirect flow.

Updated files:
- `apps/web/src/app/page.tsx`
- `apps/web/src/app/me/page.tsx`
- `apps/web/src/app/me/store/page.tsx`

## Validation
- `yarn workspace @mud/web lint` (passes; only pre-existing warnings in unrelated files)
- pre-commit hooks ran successfully during commit

## Risk
Low. This change only affects navigation semantics for OAuth start links and removes API-route usage through `Link` in favor of standard anchor navigation.
