### PR TITLE
feat(web): add skill point buttons on character page

### DIFF
--- a/apps/web/src/app/api/character/spend-skill-point/route.ts
+++ b/apps/web/src/app/api/character/spend-skill-point/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
-import { getSession } from '../../../../lib/slack-auth';
-import { spendSkillPoint } from '../../../../lib/dm-player';
+import { getSession } from '../../../lib/slack-auth';
+import { spendSkillPoint } from '../../../lib/dm-player';
 
 const VALID_ATTRIBUTES = ['strength', 'agility', 'health'] as const;
 type Attribute = (typeof VALID_ATTRIBUTES)[number];

--- a/apps/web/src/app/api/character/spend-skill-point/route.ts
+++ b/apps/web/src/app/api/character/spend-skill-point/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { getSession } from '../../../../lib/slack-auth';
+import { spendSkillPoint } from '../../../../lib/dm-player';
+
+const VALID_ATTRIBUTES = ['strength', 'agility', 'health'] as const;
+type Attribute = (typeof VALID_ATTRIBUTES)[number];
+
+export const POST = async (request: Request) => {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ message: 'Unauthorized.' }, { status: 401 });
+  }
+
+  const payload = (await request.json().catch(() => null)) as {
+    attribute?: string;
+  } | null;
+
+  if (!payload?.attribute || !VALID_ATTRIBUTES.includes(payload.attribute as Attribute)) {
+    return NextResponse.json(
+      { message: 'Missing or invalid attribute.' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await spendSkillPoint({
+      teamId: session.teamId,
+      userId: session.userId,
+      attribute: payload.attribute as Attribute,
+    });
+    return NextResponse.json(result);
+  } catch (error) {
+    return NextResponse.json(
+      { message: error instanceof Error ? error.message : 'Failed to spend skill point.' },
+      { status: 400 },
+    );
+  }
+};

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -211,6 +211,7 @@ body {
 .app-button,
 .inventory-button,
 .shop-button,
+.skill-point-btn,
 .slack-install-link,
 .slack-auth-link {
   border: 1px solid rgba(180, 130, 70, 0.55);
@@ -240,6 +241,7 @@ body {
 .app-button:hover:not(:disabled),
 .inventory-button:hover:not(:disabled),
 .shop-button:hover:not(:disabled),
+.skill-point-btn:hover:not(:disabled),
 .slack-install-link:hover,
 .slack-auth-link:hover {
   border-color: rgba(223, 164, 92, 0.8);
@@ -252,6 +254,7 @@ body {
 .app-button:active:not(:disabled),
 .inventory-button:active:not(:disabled),
 .shop-button:active:not(:disabled),
+.skill-point-btn:active:not(:disabled),
 .slack-install-link:active,
 .slack-auth-link:active {
   transform: translateY(0);
@@ -263,6 +266,7 @@ body {
 .app-button:focus-visible,
 .inventory-button:focus-visible,
 .shop-button:focus-visible,
+.skill-point-btn:focus-visible,
 .slack-install-link:focus-visible,
 .slack-auth-link:focus-visible {
   outline: 2px solid rgba(223, 164, 92, 0.7);
@@ -271,7 +275,8 @@ body {
 
 .app-button:disabled,
 .inventory-button:disabled,
-.shop-button:disabled {
+.shop-button:disabled,
+.skill-point-btn:disabled {
   opacity: 0.55;
   cursor: not-allowed;
   box-shadow: none;
@@ -532,6 +537,12 @@ body {
 .inventory-button {
   font-size: 12px;
   padding: 5px 12px;
+}
+
+.skill-point-btn {
+  font-size: 14px;
+  padding: 2px 10px;
+  line-height: 1;
 }
 
 /* Guild Store */

--- a/apps/web/src/app/lib/dm-player.ts
+++ b/apps/web/src/app/lib/dm-player.ts
@@ -86,3 +86,17 @@ export const unequipItem = async (params: {
     },
   });
 };
+
+export const spendSkillPoint = async (params: {
+  teamId: string;
+  userId: string;
+  attribute: 'strength' | 'agility' | 'health';
+}): Promise<ItemActionResponse> => {
+  return dmRequest<ItemActionResponse>('/players/spend-skill-point', 'POST', {
+    body: {
+      teamId: params.teamId,
+      userId: params.userId,
+      attribute: params.attribute,
+    },
+  });
+};

--- a/apps/web/src/app/me/AttributesClient.tsx
+++ b/apps/web/src/app/me/AttributesClient.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useGameEvents } from '../lib/use-game-events';
+import { withBasePath } from '../lib/base-path';
+
+type AttributeField = { label: string; value: string };
+
+type Props = {
+  fields: AttributeField[];
+  skillPoints: number;
+};
+
+const LABEL_TO_ATTRIBUTE: Record<string, 'strength' | 'agility' | 'health'> = {
+  Strength: 'strength',
+  Agility: 'agility',
+  Vitality: 'health',
+};
+
+export default function AttributesClient({ fields, skillPoints }: Props) {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(() => router.refresh(), [router]);
+  useGameEvents(['player:stats'], refresh);
+
+  const handleSpend = async (label: string) => {
+    const attribute = LABEL_TO_ATTRIBUTE[label];
+    if (!attribute || pending) return;
+    setPending(true);
+    setError(null);
+    try {
+      const res = await fetch(withBasePath('/api/character/spend-skill-point'), {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ attribute }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as { message?: string } | null;
+        setError(data?.message ?? 'Failed to spend skill point.');
+      } else {
+        router.refresh();
+      }
+    } catch {
+      setError('Failed to spend skill point.');
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="character-grid">
+        {fields.map((field) => (
+          <div key={field.label} className="character-field">
+            <span className="character-label">{field.label}</span>
+            <span className="character-value">{field.value}</span>
+            {skillPoints > 0 && LABEL_TO_ATTRIBUTE[field.label] ? (
+              <button
+                className="skill-point-btn"
+                disabled={pending}
+                onClick={() => handleSpend(field.label)}
+                aria-label={`Increase ${field.label}`}
+              >
+                +
+              </button>
+            ) : null}
+          </div>
+        ))}
+      </div>
+      {error ? <p className="character-note character-note--error">{error}</p> : null}
+    </>
+  );
+}

--- a/apps/web/src/app/me/page.tsx
+++ b/apps/web/src/app/me/page.tsx
@@ -4,6 +4,7 @@ import { buildInventoryModel } from '@mud/inventory';
 import { buildCharacterSheetModel } from '@mud/character-sheet';
 import { getSession } from '../lib/slack-auth';
 import InventoryClient from './inventory/InventoryClient';
+import AttributesClient from './AttributesClient';
 
 export const metadata = {
   title: 'Character',
@@ -276,19 +277,23 @@ export default async function CharacterPage() {
             <h2 className="title-font character-section-title">
               {section.title}
             </h2>
-            <div className="character-grid">
-              {section.fields.map((field) => (
-                <div key={field.label} className="character-field">
-                  <span className="character-label">{field.label}</span>
-                  <span className="character-value">{field.value}</span>
-                </div>
-              ))}
-            </div>
+            {section.title === 'Attributes' ? (
+              <AttributesClient
+                fields={section.fields}
+                skillPoints={characterSheet.skillPoints}
+              />
+            ) : (
+              <div className="character-grid">
+                {section.fields.map((field) => (
+                  <div key={field.label} className="character-field">
+                    <span className="character-label">{field.label}</span>
+                    <span className="character-value">{field.value}</span>
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         ))}
-        {characterSheet.xpContext ? (
-          <p className="character-note">{characterSheet.xpContext}</p>
-        ) : null}
         <p className="character-note">
           Skill points available: {characterSheet.skillPoints}
         </p>


### PR DESCRIPTION
## Summary
- Add `+` buttons next to Strength, Agility, and Vitality on the character sheet when the player has skill points available
- Clicking a button spends one skill point via the existing DM service endpoint (`POST /players/spend-skill-point`) and refreshes the page
- Remove the duplicate "XP needed for level N" note below the character sheet (it's already shown in the Summary grid)
- Style the new buttons using the existing design system classes (`skill-point-btn` added to `globals.css` selector groups)

## Test plan
- [ ] Log in as a player with `skillPoints > 0` — `+` buttons appear on Strength, Agility, Vitality
- [ ] Click a `+` button — stat increments, skill point count decrements, page refreshes
- [ ] Buttons disappear when skill points reach 0
- [ ] Log in as a player with `skillPoints === 0` — no `+` buttons visible
- [ ] "🏅 XP needed for level N" note is gone from below the sheet
- [ ] Button styling matches the design system (gold border, hover lift, disabled opacity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)