### PR TITLE
fix(web): disable QUIC to prevent ERR_QUIC_PROTOCOL_ERROR on SSE

### DIFF
--- a/apps/web/src/app/api/events/route.ts
+++ b/apps/web/src/app/api/events/route.ts
@@ -135,6 +135,7 @@ export const GET = async (request: Request) => {
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-cache, no-transform',
       Connection: 'keep-alive',
+      'Alt-Svc': 'clear',
     },
   });
 };

--- a/infra/terraform/kubernetes/resources.tf
+++ b/infra/terraform/kubernetes/resources.tf
@@ -902,6 +902,20 @@ resource "kubernetes_manifest" "managed_certificate" {
   }
 }
 
+resource "kubernetes_manifest" "frontend_config" {
+  manifest = {
+    apiVersion = "networking.gke.io/v1beta1"
+    kind       = "FrontendConfig"
+    metadata = {
+      name      = "mud-frontend-config"
+      namespace = kubernetes_namespace.mud.metadata[0].name
+    }
+    spec = {
+      quicOverride = "DISABLE"
+    }
+  }
+}
+
 resource "kubernetes_ingress_v1" "public" {
   metadata {
     name      = "mud-public"
@@ -910,6 +924,7 @@ resource "kubernetes_ingress_v1" "public" {
       "kubernetes.io/ingress.class"                 = "gce"
       "kubernetes.io/ingress.global-static-ip-name" = data.google_compute_global_address.gke_ingress.name
       "networking.gke.io/managed-certificates"      = kubernetes_manifest.managed_certificate.manifest["metadata"]["name"]
+      "networking.gke.io/v1beta1.FrontendConfig"    = "mud-frontend-config"
     }
   }
 


### PR DESCRIPTION
GCP's load balancer advertises HTTP/3 (QUIC) by default. Chrome negotiates QUIC for the SSE connection, which then tears down due to QUIC's incompatibility with long-lived streaming connections, causing an infinite reconnect loop.

Adds a GKE FrontendConfig with quicOverride=DISABLE to stop QUIC being advertised at the load balancer level, and adds Alt-Svc: clear to the SSE response as defense in depth for browsers that already cached a QUIC advertisement.