### PR TITLE
feat(web): post-install success page, fix Add to Slack button, improve install logging

### DIFF
--- a/apps/slack-manifest/manifest/generated/dev.json
+++ b/apps/slack-manifest/manifest/generated/dev.json
@@ -17,11 +17,16 @@
     }
   },
   "oauth_config": {
+    "pkce_enabled": false,
     "scopes": {
       "bot": [
         "im:history",
         "im:write",
-        "chat:write"
+        "chat:write",
+        "channels:manage",
+        "channels:join",
+        "channels:read",
+        "chat:write.public"
       ]
     },
     "redirect_urls": [
@@ -34,7 +39,9 @@
       "bot_events": [
         "app_home_opened",
         "app_uninstalled",
-        "message.im"
+        "message.im",
+        "member_joined_channel",
+        "member_left_channel"
       ],
       "request_url": "https://closet.battleforge.app/slack/events"
     },
@@ -44,6 +51,7 @@
     },
     "org_deploy_enabled": false,
     "socket_mode_enabled": false,
-    "token_rotation_enabled": false
+    "token_rotation_enabled": false,
+    "is_mcp_enabled": false
   }
 }

--- a/apps/slack-manifest/manifest/generated/prod.json
+++ b/apps/slack-manifest/manifest/generated/prod.json
@@ -17,10 +17,16 @@
     }
   },
   "oauth_config": {
+    "pkce_enabled": false,
     "scopes": {
       "bot": [
         "im:history",
-        "im:write"
+        "im:write",
+        "chat:write",
+        "channels:manage",
+        "channels:join",
+        "channels:read",
+        "chat:write.public"
       ]
     },
     "redirect_urls": [
@@ -33,7 +39,9 @@
       "bot_events": [
         "app_home_opened",
         "app_uninstalled",
-        "message.im"
+        "message.im",
+        "member_joined_channel",
+        "member_left_channel"
       ],
       "request_url": "https://slack.battleforge.app/slack/events"
     },
@@ -43,6 +51,7 @@
     },
     "org_deploy_enabled": false,
     "socket_mode_enabled": false,
-    "token_rotation_enabled": false
+    "token_rotation_enabled": false,
+    "is_mcp_enabled": false
   }
 }

--- a/apps/slack/src/installation-store.ts
+++ b/apps/slack/src/installation-store.ts
@@ -25,6 +25,9 @@ export class TrackingInstallationStore implements InstallationStore {
       undefined;
     if (teamId) {
       await upsertWorkspaceInstall(teamId);
+      logger?.info(
+        `install.received: teamId=${teamId} — launching battleforge bootstrap`,
+      );
       void this.bootstrapBattleforgeChannel(installation, logger);
     }
   }
@@ -56,7 +59,7 @@ export class TrackingInstallationStore implements InstallationStore {
     const botToken = installation.bot?.token;
 
     if (!teamId || !botToken) {
-      logger?.debug(
+      logger?.warn(
         'bootstrapBattleforgeChannel: missing teamId or botToken — skipping',
       );
       return;
@@ -82,8 +85,8 @@ export class TrackingInstallationStore implements InstallationStore {
             info.channel &&
             !(info.channel as { is_archived?: boolean }).is_archived
           ) {
-            logger?.debug(
-              'bootstrapBattleforgeChannel: channel already exists — skipping',
+            logger?.info(
+              `bootstrapBattleforgeChannel: channel ${workspace.battleforgeChannelId} already active for team ${teamId} — skipping`,
             );
             return;
           }
@@ -100,6 +103,9 @@ export class TrackingInstallationStore implements InstallationStore {
           is_private: false,
         });
         channelId = createResult.channel?.id;
+        logger?.info(
+          `bootstrapBattleforgeChannel: created #battleforge (${channelId}) for team ${teamId}`,
+        );
       } catch (err) {
         const slackError = err as { data?: { error?: string } };
         if (slackError.data?.error === 'name_taken') {
@@ -109,27 +115,32 @@ export class TrackingInstallationStore implements InstallationStore {
             (ch) => ch.name === 'battleforge',
           );
           channelId = existing?.id;
+          logger?.info(
+            `bootstrapBattleforgeChannel: reused existing #battleforge (${channelId}) for team ${teamId}`,
+          );
         } else {
           throw err;
         }
       }
 
       if (!channelId) {
-        logger?.debug(
-          'bootstrapBattleforgeChannel: could not determine channel ID',
+        logger?.warn(
+          `bootstrapBattleforgeChannel: could not determine channel ID for team ${teamId}`,
         );
         return;
       }
 
-      // Bug 4 fix: persist channelId immediately after create, before join/seed
       await setBattleforgeChannelId(teamId, channelId);
+      logger?.info(
+        `bootstrapBattleforgeChannel: persisted channelId=${channelId} for team ${teamId}`,
+      );
 
       // Ensure the bot is a member (best-effort)
       try {
         await web.conversations.join({ channel: channelId });
       } catch (joinErr) {
-        logger?.debug(
-          'bootstrapBattleforgeChannel: failed to join channel — non-fatal',
+        logger?.warn(
+          `bootstrapBattleforgeChannel: failed to join channel ${channelId} — non-fatal`,
           joinErr,
         );
       }
@@ -147,8 +158,8 @@ export class TrackingInstallationStore implements InstallationStore {
           });
         }
       } catch (seedErr) {
-        logger?.debug(
-          'bootstrapBattleforgeChannel: failed to seed members — non-fatal',
+        logger?.warn(
+          `bootstrapBattleforgeChannel: failed to seed members for team ${teamId} — non-fatal`,
           seedErr,
         );
       }
@@ -159,12 +170,14 @@ export class TrackingInstallationStore implements InstallationStore {
         text: 'Welcome to BattleForge! Game events show up here.',
       });
 
-      logger?.debug(
-        `bootstrapBattleforgeChannel: channel ${channelId} ready for team ${teamId}`,
+      logger?.info(
+        `bootstrapBattleforgeChannel: #battleforge ready (${channelId}) for team ${teamId}`,
       );
     } catch (error) {
-      // Never block install on channel bootstrap failures
-      logger?.debug('bootstrapBattleforgeChannel: error (non-fatal)', error);
+      logger?.error(
+        `bootstrapBattleforgeChannel: unexpected error for team ${teamId} — channel not created`,
+        error,
+      );
     }
   }
 }

--- a/apps/slack/src/main.ts
+++ b/apps/slack/src/main.ts
@@ -78,13 +78,20 @@ const app = new App({
   installerOptions: {
     directInstall: true,
     callbackOptions: {
-      successAsync: async (_installation, _installOptions, _req, res) => {
+      successAsync: async (installation, _installOptions, _req, res) => {
+        const teamId = installation.team?.id ?? 'unknown';
+        (slackLogger ?? console).info(
+          `oauth.success: teamId=${teamId} — redirecting to /installed`,
+        );
         res.writeHead(302, {
           Location: 'https://www.battleforge.app/installed',
         });
         res.end();
       },
-      failureAsync: async (_error, _installOptions, _req, res) => {
+      failureAsync: async (error, _installOptions, _req, res) => {
+        (slackLogger ?? console).warn(
+          `oauth.failure: ${(error as Error).message ?? String(error)} — redirecting to home`,
+        );
         res.writeHead(302, {
           Location: 'https://www.battleforge.app/?install_error=1',
         });


### PR DESCRIPTION
## Summary

- **Routes "Add to Slack" button through Bolt** — the homepage button was pointing directly at a hardcoded Slack OAuth URL (with stale scopes), bypassing Bolt's state generation and causing `slack_oauth_missing_state`. Now routes through `https://slack.battleforge.app/slack/install`.
- **Pixel-art post-install success page** — after OAuth completes, users land on `/installed` (styled in the 8-bit design system) with a "⚔ QUEST UNLOCKED" heading, flavor text, first-command reference grid, and an "OPEN SLACK" CTA. Bolt `callbackOptions` wired for both success and failure redirects.
- **Bootstrap logging promoted to visible levels** — all `bootstrapBattleforgeChannel` log calls were at `debug` (silent on GKE at INFO). Key lifecycle events now log at `info`, non-fatal failures at `warn`, unexpected errors at `error`. OAuth callbacks also log at `info`/`warn`.
- **CI fixes** — Playwright `site.spec.ts` selectors tightened with `.first()` / `exact: true` to handle duplicate elements added by the pixel-art hero section (pre-existing breakage from the reskin PR). Manifest `base.json` updated with `is_mcp_enabled` and `pkce_enabled` to match Slack's export and fix the manifest verify step.

## Test plan

- [ ] Click "ADD TO SLACK" on `www.battleforge.app` → flows through `/slack/install` → Slack OAuth → lands on `/installed` page
- [ ] `/installed` renders correctly: pixel-art panel, "⚔ QUEST UNLOCKED" heading, four command tiles, "OPEN SLACK" button
- [ ] Install failure (revoke mid-flow) → redirects to home with `?install_error=1`, no crash
- [ ] GKE logs show `install.received`, `oauth.success`, and `bootstrapBattleforgeChannel: #battleforge ready` at INFO level
- [ ] `yarn lint` clean, all 205 unit tests pass, Playwright E2E suite green
- [ ] `yarn slack:manifest:update:dev` verify step passes (no manifest diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)