### PR TITLE
fix(slack): handle deleted-channel name_taken in battleforge bootstrap

### DIFF
--- a/apps/slack/src/installation-store.ts
+++ b/apps/slack/src/installation-store.ts
@@ -109,15 +109,45 @@ export class TrackingInstallationStore implements InstallationStore {
       } catch (err) {
         const slackError = err as { data?: { error?: string } };
         if (slackError.data?.error === 'name_taken') {
-          // Channel exists — find it
+          // Active channel — find it
           const list = await web.conversations.list({ limit: 1000 });
-          const existing = list.channels?.find(
-            (ch) => ch.name === 'battleforge',
-          );
-          channelId = existing?.id;
-          logger?.info(
-            `bootstrapBattleforgeChannel: reused existing #battleforge (${channelId}) for team ${teamId}`,
-          );
+          const active = list.channels?.find((ch) => ch.name === 'battleforge');
+          if (active?.id) {
+            channelId = active.id;
+            logger?.info(
+              `bootstrapBattleforgeChannel: reused existing #battleforge (${channelId}) for team ${teamId}`,
+            );
+          } else {
+            // Deleted channels reserve the name but won't appear in list results.
+            // Try including archived channels to find and unarchive it.
+            const archivedList = await web.conversations.list({
+              limit: 1000,
+              exclude_archived: false,
+            });
+            const archived = archivedList.channels?.find(
+              (ch) => ch.name === 'battleforge',
+            );
+            if (archived?.id) {
+              channelId = archived.id;
+              logger?.info(
+                `bootstrapBattleforgeChannel: found archived #battleforge (${channelId}), unarchiving for team ${teamId}`,
+              );
+              await web.conversations.unarchive({ channel: channelId });
+            } else {
+              // Name reserved by a recently deleted channel — use fallback name
+              logger?.warn(
+                `bootstrapBattleforgeChannel: #battleforge name reserved (recently deleted) for team ${teamId} — creating battleforge-guild`,
+              );
+              const fallback = await web.conversations.create({
+                name: 'battleforge-guild',
+                is_private: false,
+              });
+              channelId = fallback.channel?.id;
+              logger?.info(
+                `bootstrapBattleforgeChannel: created #battleforge-guild (${channelId}) for team ${teamId}`,
+              );
+            }
+          }
         } else {
           throw err;
         }


### PR DESCRIPTION
## Summary

Fixes a bug found via GKE logs where the #battleforge channel was silently not created on install.

**Root cause:** `conversations.create` returned `name_taken` (a previously deleted channel reserves its name in Slack for ~7 days), but `conversations.list` omits deleted channels — leaving `channelId` as `undefined` and the channel ID never persisted.

**Three-path fallback now in place:**
1. Active channel found in `conversations.list` → reuse as before
2. Channel found in `conversations.list` with `exclude_archived=false` → unarchive and reuse
3. Name reserved by a recently deleted channel (neither path finds it) → create `#battleforge-guild` as fallback and warn

**Seen in logs:**
```
bootstrapBattleforgeChannel: reused existing #battleforge (undefined) for team T01CJA1PZHR
```
After fix, logs will show which of the three paths resolved the channel.

## Test plan

- [ ] Reinstall the app on a workspace where `#battleforge` was previously deleted → channel created under fallback name or unarchived
- [ ] Reinstall on a fresh workspace → `#battleforge` created normally
- [ ] Reinstall on a workspace with an active `#battleforge` → reused, no duplicate created
- [ ] GKE logs show resolved channel ID (not `undefined`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)